### PR TITLE
Added subsampled Stephenson2021 COVID19 dataset

### DIFF
--- a/pertpy/data/__init__.py
+++ b/pertpy/data/__init__.py
@@ -12,4 +12,5 @@ from pertpy.data._datasets import (
     papalexi_2021,
     sc_sim_augur,
     sciplex3_raw,
+    stephenson_2021_subsampled,
 )

--- a/pertpy/data/_datasets.py
+++ b/pertpy/data/_datasets.py
@@ -380,3 +380,34 @@ def kang_2018() -> AnnData:  # pragma: no cover
         adata = sc.read_h5ad(output_file_path)
 
     return adata
+
+
+def stephenson_2021_subsampled() -> AnnData:  # pragma: no cover
+    """Processed 10X 5' scRNA-seq data from PBMC of COVID-19 patients and healthy donors
+
+    The study
+    - Downsampled to approx. 500 cells per donor
+    - Both COVID-19 and control samples were mapped to reference atlas of healthy PBMCs with scArches
+
+    Reference:
+        Stephenson, E., Reynolds, G., Botting, R. A., et al. (2021).
+        Single-cell multi-omics analysis of the immune response in COVID-19.
+        Nature Medicine, 27(5). https://doi.org/10.1038/s41591-021-01329-2
+
+
+    Returns:
+        :class:`~anndata.AnnData` object of scRNA-seq profiles
+    """
+    output_file_name = "stephenson_2021_subsampled.h5ad"
+    output_file_path = settings.datasetdir.__str__() + "/" + output_file_name
+    if not Path(output_file_path).exists():
+        _download(
+            url="https://figshare.com/ndownloader/files/38171703",
+            output_file_name=output_file_name,
+            output_path=settings.datasetdir,
+            is_zip=False,
+        )
+        adata = sc.read_h5ad(filename=settings.datasetdir.__str__() + "/" + output_file_name)
+    else:
+        adata = sc.read_h5ad(output_file_path)
+    return adata

--- a/pertpy/data/_datasets.py
+++ b/pertpy/data/_datasets.py
@@ -385,9 +385,9 @@ def kang_2018() -> AnnData:  # pragma: no cover
 def stephenson_2021_subsampled() -> AnnData:  # pragma: no cover
     """Processed 10X 5' scRNA-seq data from PBMC of COVID-19 patients and healthy donors
 
-    The study
-    - Downsampled to approx. 500 cells per donor
-    - Both COVID-19 and control samples were mapped to reference atlas of healthy PBMCs with scArches
+    The study profiled peripheral blood mononuclear cells from 90 COVID-19 patients with different disease severity and 23 healthy control donors.
+    Here the dataset was downsampled to approx. 500 cells per donor and cells were mapped to a reference atlas of healthy PBMCs from 12 studies
+    with scArches.
 
     Reference:
         Stephenson, E., Reynolds, G., Botting, R. A., et al. (2021).


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->
As mentioned in https://github.com/theislab/pertpy-tutorials/pull/4, added data loader for subsampled Stephenson2021 dataset. 

The dataset is subsampled to have approx 500 cells per donors (before QC filtering) and batch corrected space is in `adata.obsm['X_scVI']` (mapped to PBMC ref atlas w scArches). Not sure if it's important to have a reference for how the data was preprocessed here, but if needed this should come out on biorxiv in a week or so (submitted today). 