### PR TITLE
Solve pre-commit prettier and isort version incompatibility issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,8 +52,9 @@ repos:
       rev: v2.5.1
       hooks:
           - id: prettier
+            language_version: "17.9.1"
     - repo: https://github.com/pycqa/isort
-      rev: 5.9.3
+      rev: 5.12.0
       hooks:
           - id: isort
             name: isort (python)


### PR DESCRIPTION

**PR Checklist**

-   [x] Referenced issue is linked
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**

Changed prettier and isort based on the following issues:

[prettier version problem causing the node incompatibility](https://github.com/scverse/cookiecutter-scverse/pull/144)

[isort incompatibility with newer versions of poetry](https://stackoverflow.com/questions/75269700/pre-commit-fails-to-install-isort-5-11-4-with-error-runtimeerror-the-poetry-co)

**Technical details**

-

**Additional context**

-