### PR TITLE
changes default settings of coda and milo

### DIFF
--- a/pertpy/plot/_coda.py
+++ b/pertpy/plot/_coda.py
@@ -642,7 +642,9 @@ class CodaPlot:
 
     @staticmethod
     def draw_tree(  # pragma: no cover
-        tree: Tree,
+        data: Union[AnnData, MuData],
+        modality_key: str = "coda",
+        tree: Union[Tree, str] = "tree",
         tight_text: Optional[bool] = False,
         show_scale: Optional[bool] = False,
         show: Optional[bool] = True,
@@ -655,7 +657,9 @@ class CodaPlot:
         """Plot a tree using input ete3 tree object.
 
         Args:
-            tree: A ete3 tree object.
+            data: AnnData object or MuData object.
+            modality_key: If data is a MuData object, specify which modality to use. Defaults to "coda".
+            tree: A ete3 tree object or a str to indicate the tree stored in `.uns`. Defaults to "tree".
             tight_text: When False, boundaries of the text are approximated according to general font metrics, producing slightly worse aligned text faces but improving the performance of tree visualization in scenes with a lot of text faces. Default to False.
             show_scale: Include the scale legend in the tree image or not. Default to False.
             show: If True, plot the tree inline. If false, return tree and tree_style objects. Defaults to True.
@@ -668,6 +672,12 @@ class CodaPlot:
         Returns:
             Depending on `show`, returns :class:`ete3.TreeNode` and :class:`ete3.TreeStyle` (`show = False`) or  plot the tree inline (`show = False`)
         """
+        if isinstance(data, MuData):
+            data = data[modality_key]
+        if isinstance(data, AnnData):
+            data = data
+        if isinstance(tree, str):
+            tree = data.uns[tree]
 
         def my_layout(node):
             text_face = TextFace(node.name, tight_text=tight_text)
@@ -687,9 +697,9 @@ class CodaPlot:
     @staticmethod
     def draw_effects(  # noqa: C901 # pragma: no cover
         data: Union[AnnData, MuData],
-        tree: Union[Tree, str],
         covariate: str,
         modality_key: str = "coda",
+        tree: Union[Tree, str] = "tree",
         show_legend: Optional[bool] = None,
         show_leaf_effects: Optional[bool] = False,
         tight_text: Optional[bool] = False,
@@ -705,9 +715,9 @@ class CodaPlot:
 
         Args:
             data: AnnData object or MuData object.
-            tree: A ete3 tree object or a str to indicate the tree stored in `.uns`.
-            covariate: The covariate, whose effects should be plotted
+            covariate: The covariate, whose effects should be plotted.
             modality_key: If data is a MuData object, specify which modality to use. Defaults to "coda".
+            tree: A ete3 tree object or a str to indicate the tree stored in `.uns`. Defaults to "tree".
             show_legend: If show legend of nodes significant effects or not. Default is False if show_leaf_effects is True.
             show_leaf_effects: If True, plot bar plots which indicate leave-level significant effects. Defaults to False.
             tight_text: When False, boundaries of the text are approximated according to general font metrics, producing slightly worse aligned text faces but improving the performance of tree visualization in scenes with a lot of text faces. Defaults to False.

--- a/pertpy/plot/_milopy.py
+++ b/pertpy/plot/_milopy.py
@@ -38,7 +38,7 @@ class MilopyPlot:
                   Infer the filetype if ending on {`'.pdf'`, `'.png'`, `'.svg'`}.
             **kwargs: Additional arguments to `scanpy.pl.embedding`.
         """
-        nhood_adata = mdata["milo_compositional"].T.copy()
+        nhood_adata = mdata["milo"].T.copy()
 
         if "Nhood_size" not in nhood_adata.obs.columns:
             raise KeyError(
@@ -120,10 +120,10 @@ class MilopyPlot:
             subset_nhoods: List of nhoods to plot. If None, plot all nhoods. (default: None)
         """
         try:
-            nhood_adata = mdata["milo_compositional"].T.copy()
+            nhood_adata = mdata["milo"].T.copy()
         except KeyError:
             print(
-                "mdata should be a MuData object with two slots: feature_key and 'milo_compositional' - please run milopy.count_nhoods(adata) first"
+                "mdata should be a MuData object with two slots: feature_key and 'milo' - please run milopy.count_nhoods(adata) first"
             )
 
         if subset_nhoods is not None:
@@ -216,10 +216,10 @@ class MilopyPlot:
             log_counts: Whether to plot log1p of cell counts. (default: False)
         """
         try:
-            nhood_adata = mdata["milo_compositional"].T.copy()
+            nhood_adata = mdata["milo"].T.copy()
         except KeyError:
             print(
-                "milo_mdata should be a MuData object with two slots: feature_key and 'milo_compositional' - please run milopy.count_nhoods(adata) first"
+                "milo_mdata should be a MuData object with two slots: feature_key and 'milo' - please run milopy.count_nhoods(adata) first"
             )
 
         if subset_nhoods is None:

--- a/pertpy/tools/_milopy.py
+++ b/pertpy/tools/_milopy.py
@@ -41,7 +41,7 @@ class Milopy:
         Returns:
             MuData: MuData object with original AnnData (default is `mudata[feature_key]`).
         """
-        mdata = MuData({feature_key: input, "milo_compositional": AnnData()})
+        mdata = MuData({feature_key: input, "milo": AnnData()})
 
         return mdata
 
@@ -179,11 +179,11 @@ class Milopy:
 
         Returns:
             MuData object storing the original (i.e. rna) AnnData in `mudata[feature_key]`
-            and the compositional anndata storing the neighbourhood cell counts in `mudata['milo_compositional']`.
+            and the compositional anndata storing the neighbourhood cell counts in `mudata['milo']`.
             Here:
-            - `mudata['milo_compositional'].obs_names` are samples (defined from `adata.obs['sample_col']`)
-            - `mudata['milo_compositional'].var_names` are neighbourhoods
-            - `mudata['milo_compositional'].X` is the matrix counting the number of cells from each
+            - `mudata['milo'].obs_names` are samples (defined from `adata.obs['sample_col']`)
+            - `mudata['milo'].var_names` are neighbourhoods
+            - `mudata['milo'].X` is the matrix counting the number of cells from each
             sample in each neighbourhood
         """
         if isinstance(data, MuData):
@@ -213,10 +213,10 @@ class Milopy:
         ].values
 
         if is_MuData is True:
-            data.mod["milo_compositional"] = sample_adata
+            data.mod["milo"] = sample_adata
             return data
         else:
-            milo_mdata = MuData({feature_key: adata, "milo_compositional": sample_adata})
+            milo_mdata = MuData({feature_key: adata, "milo": sample_adata})
             return milo_mdata
 
     def da_nhoods(
@@ -235,23 +235,23 @@ class Milopy:
             mdata: MuData object
             design: formula for the test, following glm syntax from R (e.g. '~ condition'). Terms should be columns in `milo_mdata[feature_key].obs`.
             model_contrasts: A string vector that defines the contrasts used to perform DA testing, following glm syntax from R (e.g. "conditionDisease - conditionControl"). If no contrast is specified (default), then the last categorical level in condition of interest is used as the test group. Defaults to None.
-            subset_samples: subset of samples (obs in `milo_mdata['milo_compositional']`) to use for the test. Defaults to None.
+            subset_samples: subset of samples (obs in `milo_mdata['milo']`) to use for the test. Defaults to None.
             add_intercept: whether to include an intercept in the model. If False, this is equivalent to adding + 0 in the design formula. When model_contrasts is specified, this is set to False by default. Defaults to True.
             feature_key: If input data is MuData, specify key to cell-level AnnData object. (default: 'rna')
             solver: The solver to fit the model to. One of "edger" (requires R, rpy2 and edgeR to be installed) or "batchglm"
 
         Returns:
-            None, modifies `milo_mdata['milo_compositional']` in place, adding the results of the DA test to `.var`:
+            None, modifies `milo_mdata['milo']` in place, adding the results of the DA test to `.var`:
             - `logFC` stores the log fold change in cell abundance (coefficient from the GLM)
             - `PValue` stores the p-value for the QLF test before multiple testing correction
             - `SpatialFDR` stores the the p-value adjusted for multiple testing to limit the false discovery rate,
                 calculated with weighted Benjamini-Hochberg procedure
         """
         try:
-            sample_adata = mdata["milo_compositional"]
+            sample_adata = mdata["milo"]
         except KeyError:
             print(
-                "[bold red]milo_mdata should be a MuData object with two slots: feature_key and 'milo_compositional' - please run milopy.count_nhoods() first"
+                "[bold red]milo_mdata should be a MuData object with two slots: feature_key and 'milo' - please run milopy.count_nhoods() first"
             )
             raise
         adata = mdata[feature_key]
@@ -369,16 +369,16 @@ class Milopy:
 
         Returns:
             None. Adds in place:
-            - `milo_mdata['milo_compositional'].var["nhood_annotation"]`: assigning a label to each nhood
-            - `milo_mdata['milo_compositional'].var["nhood_annotation_frac"]` stores the fraciton of cells in the neighbourhood with the assigned label
-            - `milo_mdata['milo_compositional'].varm['frac_annotation']`: stores the fraction of cells from each label in each nhood
-            - `milo_mdata['milo_compositional'].uns["annotation_labels"]`: stores the column names for `milo_mdata['milo_compositional'].varm['frac_annotation']`
+            - `milo_mdata['milo'].var["nhood_annotation"]`: assigning a label to each nhood
+            - `milo_mdata['milo'].var["nhood_annotation_frac"]` stores the fraciton of cells in the neighbourhood with the assigned label
+            - `milo_mdata['milo'].varm['frac_annotation']`: stores the fraction of cells from each label in each nhood
+            - `milo_mdata['milo'].uns["annotation_labels"]`: stores the column names for `milo_mdata['milo'].varm['frac_annotation']`
         """
         try:
-            sample_adata = mdata["milo_compositional"]
+            sample_adata = mdata["milo"]
         except KeyError:
             print(
-                "milo_mdata should be a MuData object with two slots: feature_key and 'milo_compositional' - please run milopy.count_nhoods(adata) first"
+                "milo_mdata should be a MuData object with two slots: feature_key and 'milo' - please run milopy.count_nhoods(adata) first"
             )
             raise
         adata = mdata[feature_key]
@@ -410,11 +410,11 @@ class Milopy:
 
         Returns:
             None. Adds in place:
-            - `milo_mdata['milo_compositional'].var["nhood_{anno_col}"]`: assigning a continuous value to each nhood
+            - `milo_mdata['milo'].var["nhood_{anno_col}"]`: assigning a continuous value to each nhood
         """
-        if "milo_compositional" not in mdata.mod:
+        if "milo" not in mdata.mod:
             raise ValueError(
-                "milo_mdata should be a MuData object with two slots: feature_key and 'milo_compositional' - please run milopy.count_nhoods(adata) first"
+                "milo_mdata should be a MuData object with two slots: feature_key and 'milo' - please run milopy.count_nhoods(adata) first"
             )
         adata = mdata[feature_key]
 
@@ -428,24 +428,24 @@ class Milopy:
 
         mean_anno_val = anno_val.toarray() / np.array(adata.obsm["nhoods"].T.sum(1))
 
-        mdata["milo_compositional"].var[f"nhood_{anno_col}"] = mean_anno_val
+        mdata["milo"].var[f"nhood_{anno_col}"] = mean_anno_val
 
     def add_covariate_to_nhoods_var(self, mdata: MuData, new_covariates: list[str], feature_key: str | None = "rna"):
         """Add covariate from cell-level obs to sample-level obs. These should be covariates for which a single value can be assigned to each sample.
 
         Args:
             mdata: MuData object
-            new_covariates: columns in `milo_mdata[feature_key].obs` to add to `milo_mdata['milo_compositional'].obs`.
+            new_covariates: columns in `milo_mdata[feature_key].obs` to add to `milo_mdata['milo'].obs`.
             feature_key: If input data is MuData, specify key to cell-level AnnData object. (default: 'rna')
 
         Returns:
-            None, adds columns to `milo_mdata['milo_compositional']` in place
+            None, adds columns to `milo_mdata['milo']` in place
         """
         try:
-            sample_adata = mdata["milo_compositional"]
+            sample_adata = mdata["milo"]
         except KeyError:
             print(
-                "milo_mdata should be a MuData object with two slots: feature_key and 'milo_compositional' - please run milopy.count_nhoods(adata) first"
+                "milo_mdata should be a MuData object with two slots: feature_key and 'milo' - please run milopy.count_nhoods(adata) first"
             )
             raise
         adata = mdata[feature_key]
@@ -480,19 +480,19 @@ class Milopy:
             feature_key: If input data is MuData, specify key to cell-level AnnData object. (default: 'rna')
 
         Returns:
-            - `milo_mdata['milo_compositional'].varp['nhood_connectivities']`: graph of overlap between neighbourhoods (i.e. no of shared cells)
-            - `milo_mdata['milo_compositional'].var["Nhood_size"]`: number of cells in neighbourhoods
+            - `milo_mdata['milo'].varp['nhood_connectivities']`: graph of overlap between neighbourhoods (i.e. no of shared cells)
+            - `milo_mdata['milo'].var["Nhood_size"]`: number of cells in neighbourhoods
         """
         adata = mdata[feature_key]
         # # Add embedding positions
-        mdata["milo_compositional"].varm["X_milo_graph"] = adata[adata.obs["nhood_ixs_refined"] == 1].obsm[basis]
+        mdata["milo"].varm["X_milo_graph"] = adata[adata.obs["nhood_ixs_refined"] == 1].obsm[basis]
         # Add nhood size
-        mdata["milo_compositional"].var["Nhood_size"] = np.array(adata.obsm["nhoods"].sum(0)).flatten()
+        mdata["milo"].var["Nhood_size"] = np.array(adata.obsm["nhoods"].sum(0)).flatten()
         # Add adjacency graph
-        mdata["milo_compositional"].varp["nhood_connectivities"] = adata.obsm["nhoods"].T.dot(adata.obsm["nhoods"])
-        mdata["milo_compositional"].varp["nhood_connectivities"].setdiag(0)
-        mdata["milo_compositional"].varp["nhood_connectivities"].eliminate_zeros()
-        mdata["milo_compositional"].uns["nhood"] = {
+        mdata["milo"].varp["nhood_connectivities"] = adata.obsm["nhoods"].T.dot(adata.obsm["nhoods"])
+        mdata["milo"].varp["nhood_connectivities"].setdiag(0)
+        mdata["milo"].varp["nhood_connectivities"].eliminate_zeros()
+        mdata["milo"].uns["nhood"] = {
             "connectivities_key": "nhood_connectivities",
             "distances_key": "",
         }
@@ -506,13 +506,13 @@ class Milopy:
             feature_key: If input data is MuData, specify key to cell-level AnnData object. (default: 'rna')
 
         Returns:
-            Updates adata in place to store the matrix of average expression in each neighbourhood in `milo_mdata['milo_compositional'].varm['expr']`
+            Updates adata in place to store the matrix of average expression in each neighbourhood in `milo_mdata['milo'].varm['expr']`
         """
         try:
-            sample_adata = mdata["milo_compositional"]
+            sample_adata = mdata["milo"]
         except KeyError:
             print(
-                "milo_mdata should be a MuData object with two slots: feature_key and 'milo_compositional' - please run milopy.count_nhoods(adata) first"
+                "milo_mdata should be a MuData object with two slots: feature_key and 'milo' - please run milopy.count_nhoods(adata) first"
             )
             raise
         adata = mdata[feature_key]

--- a/tests/tools/test_milopy.py
+++ b/tests/tools/test_milopy.py
@@ -70,11 +70,11 @@ class TestMilopy:
         top_a = adata.obs.iloc[nh_cells].value_counts(sample_col).values.ravel()
 
         # Check it matches the one calculated
-        sample_adata = milo_mdata["milo_compositional"]
+        sample_adata = milo_mdata["milo"]
         df = pd.DataFrame(sample_adata.X.T[nh, :].toarray()).T
         df.index = sample_adata.obs_names
         top_b = df.sort_values(0, ascending=False).values.ravel()
-        assert all((top_b - top_a) == 0), 'The counts for samples in milo_mdata["milo_compositional"] does not match'
+        assert all((top_b - top_a) == 0), 'The counts for samples in milo_mdata["milo"] does not match'
 
     def test_count_nhoods_missing_nhoods(self, adata):
         adata = adata.copy()
@@ -97,12 +97,12 @@ class TestMilopy:
         top_a = adata.obs.iloc[nh_cells].value_counts(sample_col).index[0]
 
         # Check it matches the one calculated
-        sample_adata = milo_mdata["milo_compositional"]
+        sample_adata = milo_mdata["milo"]
         df = pd.DataFrame(sample_adata.X.T[nh, :].toarray()).T
         df.index = sample_adata.obs_names
         top_b = df.sort_values(0, ascending=False).index[0]
 
-        assert top_a == top_b, 'The order of samples in milo_mdata["milo_compositional"] does not match'
+        assert top_a == top_b, 'The order of samples in milo_mdata["milo"] does not match'
 
     # @pytest.mark.skipif(r_dependency is None, reason="Require R dependecy")
     @pytest.fixture
@@ -146,7 +146,7 @@ class TestMilopy:
     def test_da_nhoods_pvalues(self, da_nhoods_mdata):
         mdata = da_nhoods_mdata.copy()
         self.milo.da_nhoods(mdata, design="~condition")
-        sample_adata = mdata["milo_compositional"].copy()
+        sample_adata = mdata["milo"].copy()
         min_p, max_p = sample_adata.var["PValue"].min(), sample_adata.var["PValue"].max()
         assert (min_p >= 0) & (max_p <= 1), "P-values are not between 0 and 1"
 
@@ -154,7 +154,7 @@ class TestMilopy:
     def test_da_nhoods_fdr(self, da_nhoods_mdata):
         mdata = da_nhoods_mdata.copy()
         self.milo.da_nhoods(mdata, design="~condition")
-        sample_adata = mdata["milo_compositional"].copy()
+        sample_adata = mdata["milo"].copy()
         assert np.all(
             np.round(sample_adata.var["PValue"], 10) <= np.round(sample_adata.var["SpatialFDR"], 10)
         ), "FDR is higher than uncorrected P-values"
@@ -167,9 +167,9 @@ class TestMilopy:
             adata.obs["condition"].astype("category").cat.reorder_categories(["ConditionA", "ConditionB"])
         )
         self.milo.da_nhoods(mdata, design="~condition")
-        default_results = mdata["milo_compositional"].var.copy()
+        default_results = mdata["milo"].var.copy()
         self.milo.da_nhoods(mdata, design="~condition", model_contrasts="conditionConditionB-conditionConditionA")
-        contr_results = mdata["milo_compositional"].var.copy()
+        contr_results = mdata["milo"].var.copy()
 
         assert np.corrcoef(contr_results["SpatialFDR"], default_results["SpatialFDR"])[0, 1] > 0.99
         assert np.corrcoef(contr_results["logFC"], default_results["logFC"])[0, 1] > 0.99
@@ -196,28 +196,28 @@ class TestMilopy:
 
     def test_annotate_nhoods_missing_samples(self, annotate_nhoods_mdata):
         mdata = annotate_nhoods_mdata.copy()
-        del mdata.mod["milo_compositional"]
+        del mdata.mod["milo"]
         with pytest.raises(ValueError):
             self.milo.annotate_nhoods_continuous(mdata, anno_col="S_score")
 
     def test_annotate_nhoods_continuous_mean_range(self, annotate_nhoods_mdata):
         mdata = annotate_nhoods_mdata.copy()
         self.milo.annotate_nhoods_continuous(mdata, anno_col="S_score")
-        assert mdata["milo_compositional"].var["nhood_S_score"].max() < mdata["rna"].obs["S_score"].max()
-        assert mdata["milo_compositional"].var["nhood_S_score"].min() > mdata["rna"].obs["S_score"].min()
+        assert mdata["milo"].var["nhood_S_score"].max() < mdata["rna"].obs["S_score"].max()
+        assert mdata["milo"].var["nhood_S_score"].min() > mdata["rna"].obs["S_score"].min()
 
     def test_annotate_nhoods_continuous_correct_mean(self, annotate_nhoods_mdata):
         mdata = annotate_nhoods_mdata.copy()
         self.milo.annotate_nhoods_continuous(mdata, anno_col="S_score")
-        i = np.random.choice(np.arange(mdata["milo_compositional"].n_obs))
+        i = np.random.choice(np.arange(mdata["milo"].n_obs))
         mean_val_nhood = mdata["rna"].obs[mdata["rna"].obsm["nhoods"][:, i].toarray() == 1]["S_score"].mean()
-        assert mdata["milo_compositional"].var["nhood_S_score"][i] == pytest.approx(mean_val_nhood, 0.0001)
+        assert mdata["milo"].var["nhood_S_score"][i] == pytest.approx(mean_val_nhood, 0.0001)
 
     def test_annotate_nhoods_annotation_frac_range(self, annotate_nhoods_mdata):
         mdata = annotate_nhoods_mdata.copy()
         self.milo.annotate_nhoods(mdata, anno_col="louvain")
-        assert mdata["milo_compositional"].var["nhood_annotation_frac"].max() <= 1.0
-        assert mdata["milo_compositional"].var["nhood_annotation_frac"].min() >= 0.0
+        assert mdata["milo"].var["nhood_annotation_frac"].max() <= 1.0
+        assert mdata["milo"].var["nhood_annotation_frac"].min() >= 0.0
 
     def test_annotate_nhoods_cont_gives_error(self, annotate_nhoods_mdata):
         mdata = annotate_nhoods_mdata.copy()
@@ -253,11 +253,11 @@ class TestMilopy:
     def test_add_nhood_expression_nhood_mean_range(self, add_nhood_expression_mdata):
         mdata = add_nhood_expression_mdata.copy()
         self.milo.add_nhood_expression(mdata)
-        assert mdata["milo_compositional"].varm["expr"].shape[1] == mdata["rna"].n_vars
+        assert mdata["milo"].varm["expr"].shape[1] == mdata["rna"].n_vars
         mdata = add_nhood_expression_mdata.copy()
         self.milo.add_nhood_expression(mdata)
         nhood_ix = 10
-        nhood_gex = mdata["milo_compositional"].varm["expr"][nhood_ix, :].toarray().ravel()
+        nhood_gex = mdata["milo"].varm["expr"][nhood_ix, :].toarray().ravel()
         nhood_cells = mdata["rna"].obs_names[mdata["rna"].obsm["nhoods"][:, nhood_ix].toarray().ravel() == 1]
         mean_gex = np.array(mdata["rna"][nhood_cells].X.mean(axis=0)).ravel()
         assert nhood_gex == pytest.approx(mean_gex, 0.0001)


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [ ] Referenced issue is linked
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

1. Change slot name of milo. (From "milo_compositional" to "milo", keep it consistent to "coda")
2. Improve coda.draw_tree(). Make it compatible to MuData and AnnData. Add default settings of using "tree" in .uns and "coda" in MuData.

**Technical details**

<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

**Additional context**

<!-- Add any other context or screenshots here. -->
