### PR TITLE
scCODA: add low/high acceptance probability warnings

### DIFF
--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -224,6 +224,14 @@ class CompositionalModel2(ABC):
             extra_fields=extra_fields,
         )
 
+        acc_rate = np.array(self.mcmc.last_state.mean_accept_prob)
+        if acc_rate < 0.5:
+            print(f"[bold red]Acceptance rate unusually low ({acc_rate} < 0.5)! Results might be incorrect! "
+                            f"Please check feasibility of results and re-run the sampling step with a different rng_key if necessary.")
+        if acc_rate > 0.95:
+            print(f"[bold red]Acceptance rate unusually high ({acc_rate} > 0.95)! Results might be incorrect! "
+                            f"Please check feasibility of results and re-run the sampling step with a different rng_key if necessary.")
+
         # Set acceptance rate and save sampled values to `sample_adata.uns`
         sample_adata.uns["scCODA_params"]["mcmc"]["acceptance_rate"] = np.array(self.mcmc.last_state.mean_accept_prob)
         samples = self.mcmc.get_samples()

--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -225,7 +225,7 @@ class CompositionalModel2(ABC):
         )
 
         acc_rate = np.array(self.mcmc.last_state.mean_accept_prob)
-        if acc_rate < 0.5:
+        if acc_rate < 0.6:
             print(f"[bold red]Acceptance rate unusually low ({acc_rate} < 0.5)! Results might be incorrect! "
                             f"Please check feasibility of results and re-run the sampling step with a different rng_key if necessary.")
         if acc_rate > 0.95:

--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -226,11 +226,15 @@ class CompositionalModel2(ABC):
 
         acc_rate = np.array(self.mcmc.last_state.mean_accept_prob)
         if acc_rate < 0.6:
-            print(f"[bold red]Acceptance rate unusually low ({acc_rate} < 0.5)! Results might be incorrect! "
-                            f"Please check feasibility of results and re-run the sampling step with a different rng_key if necessary.")
+            print(
+                f"[bold red]Acceptance rate unusually low ({acc_rate} < 0.5)! Results might be incorrect! "
+                f"Please check feasibility of results and re-run the sampling step with a different rng_key if necessary."
+            )
         if acc_rate > 0.95:
-            print(f"[bold red]Acceptance rate unusually high ({acc_rate} > 0.95)! Results might be incorrect! "
-                            f"Please check feasibility of results and re-run the sampling step with a different rng_key if necessary.")
+            print(
+                f"[bold red]Acceptance rate unusually high ({acc_rate} > 0.95)! Results might be incorrect! "
+                f"Please check feasibility of results and re-run the sampling step with a different rng_key if necessary."
+            )
 
         # Set acceptance rate and save sampled values to `sample_adata.uns`
         sample_adata.uns["scCODA_params"]["mcmc"]["acceptance_rate"] = np.array(self.mcmc.last_state.mean_accept_prob)


### PR DESCRIPTION
**PR Checklist**

-   [x] Referenced issue is linked
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**

- Added warning notes if acceptance probability of MCMC sampling is too high (>0.95) or too low (<0.6)

**Technical details**

Sometimes, the MCMC samplers in scCODA/tascCODA do not converge or converge to the wrong local minimum. This is usually due to bad initialization values and can be fixed by re-running with a different rng key.
An unusually low or high acceptance rate is a good indicator for a misspecified sampler, but there are no strict bounds for good acceptance rates. Therefore, we can only display a message and ask users to check whether results are feasible

**Additional context**

In response to #359. 
