### PR TITLE
fix naming of example data in doc examples

### DIFF
--- a/pertpy/tools/_distances/_distances.py
+++ b/pertpy/tools/_distances/_distances.py
@@ -48,7 +48,7 @@ class Distance:
 
     Examples:
         >>> import pertpy as pt
-        >>> adata = pt.dt.distance_example_data()
+        >>> adata = pt.dt.distance_example()
         >>> Distance = pt.tools.Distance(metric="edistance")
         >>> X = adata.obsm["X_pca"][adata.obs["perturbation"] == "p-sgCREB1-2"]
         >>> Y = adata.obsm["X_pca"][adata.obs["perturbation"] == "control"]
@@ -100,7 +100,7 @@ class Distance:
 
         Examples:
             >>> import pertpy as pt
-            >>> adata = pt.dt.distance_example_data()
+            >>> adata = pt.dt.distance_example()
             >>> Distance = pt.tools.Distance(metric="edistance")
             >>> X = adata.obsm["X_pca"][adata.obs["perturbation"] == "p-sgCREB1-2"]
             >>> Y = adata.obsm["X_pca"][adata.obs["perturbation"] == "control"]
@@ -131,9 +131,9 @@ class Distance:
 
         Examples:
             >>> import pertpy as pt
-            >>> adata = pt.dt.distance_example_data()
+            >>> adata = pt.dt.distance_example()
             >>> Distance = pt.tools.Distance(metric="edistance")
-            >>> pairwise_df = distance.pairwise(adata, groupby="perturbation")
+            >>> pairwise_df = Distance.pairwise(adata, groupby="perturbation")
         """
         groups = adata.obs[groupby].unique() if groups is None else groups
         grouping = adata.obs[groupby].copy()
@@ -205,9 +205,9 @@ class Distance:
 
         Examples:
             >>> import pertpy as pt
-            >>> adata = pt.dt.distance_example_data()
+            >>> adata = pt.dt.distance_example()
             >>> Distance = pt.tools.Distance(metric="edistance")
-            >>> pairwise_df = distance.onesided_distances(adata, groupby="perturbation", selected_group="control")
+            >>> pairwise_df = Distance.onesided_distances(adata, groupby="perturbation", selected_group="control")
         """
         groups = adata.obs[groupby].unique() if groups is None else groups
         grouping = adata.obs[groupby].copy()


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**
The documentation examples of `pertpy.tools.Distance` had an outdated naming for the example data, and a minor bug in variable naming.
Both would be fixed in this PR.
<!-- Please state what you've changed and how it might affect the user. -->

**Technical details**
n/a
<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

**Additional context**
The outdated naming has been adressed in other files in #384 and [this commit](https://github.com/theislab/pertpy-tutorials/commit/5230af1bbc372e9d1e3207dbddcfb94cb46dd681).
<!-- Add any other context or screenshots here. -->
