### PR TITLE
Installation Apple Silicon

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,7 +18,10 @@ cd pertpy
 pip install -e ".[dev,test,doc]"
 ```
 
-_Note:_ If you're working on an Apple Silicon machine, the installation is slightly more complex. In that case, follow the [steps described in the Installation guide](installation.md#apple-silicon) and replace the last two steps described there with the code above.
+```{note}
+If you're working on an Apple Silicon machine, the installation is slightly more complex. In that case, follow
+the steps described in the Apple Silicon section of the installation guide and replace the last two steps described there with the code above.
+```
 
 ## Code-style
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,6 +17,7 @@ git clone https://github.com/theislab/pertpy.git
 cd pertpy
 pip install -e ".[dev,test,doc]"
 ```
+
 _Note:_ If you're working on an Apple Silicon machine, the installation is slightly more complex. In that case, follow the [steps described in the Installation guide](installation.md#apple-silicon) and replace the last two steps described there with the code above.
 
 ## Code-style

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -13,9 +13,11 @@ In addition to the packages needed to _use_ this package, you need additional py
 the documentation_. It's easy to install them using `pip`:
 
 ```bash
+git clone https://github.com/theislab/pertpy.git
 cd pertpy
 pip install -e ".[dev,test,doc]"
 ```
+_Note:_ If you're working on an Apple Silicon machine, the installation is slightly more complex. In that case, follow the [steps described in the Installation guide](installation.md#apple-silicon) and replace the last two steps described there with the code above.
 
 ## Code-style
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,11 +71,13 @@ Follow these steps to install pertpy on an Apple Silicon machine (tested on a Ma
     ```
 
 5. Go inside the pertpy folder and install pertpy
-   ```console
-   $ cd pertpy
-   $ pip install .
+    ```console
+    $ cd pertpy
+    $ pip install .
     ```
-    Now you're ready to use pertpy as usual within the environment (``import pertpy``).
+    Now you're ready to use pertpy as usual within the environment (`import pertpy`).
+    ```
+
     ```
 
 [github repo]: https://github.com/theislab/pertpy

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,7 +41,7 @@ $ make install
 ```
 
 ## Apple Silicon
-If you want to install and use pertpy on a machine with MacOS and M-Chip, the installation is slightly more complex.
+If you want to install and use pertpy on a machine with macOS and M-Chip, the installation is slightly more complex.
 This is because pertpy depends on [scvi-tools], which can currently only run on Apple Silicon machines when installed
 using a native python version (due to a dependency on jax, which cannot be run via Rosetta).
 
@@ -71,7 +71,7 @@ Follow these steps to install pertpy on an Apple Silicon machine (tested on a Ma
    $ cd pertpy
    $ pip install .
    ```
-Now you're ready to use pertpy as usual within the environment (``ìmport pertpy``).
+Now you're ready to use pertpy as usual within the environment (``import pertpy``).
 
 [github repo]: https://github.com/theislab/pertpy
 [pip]: https://pip.pypa.io

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,6 +41,7 @@ $ make install
 ```
 
 ## Apple Silicon
+
 If you want to install and use pertpy on a machine with macOS and M-Chip, the installation is slightly more complex.
 This is because pertpy depends on [scvi-tools], which can currently only run on Apple Silicon machines when installed
 using a native python version (due to a dependency on jax, which cannot be run via Rosetta).
@@ -51,27 +52,31 @@ Follow these steps to install pertpy on an Apple Silicon machine (tested on a Ma
 
 2. Install Apple Silicon version of Mambaforge (If you already have Anaconda/Miniconda installed, make sure
    having both mamba and conda won't cause conflicts)
-   ```console
-   $ brew install --cask mambaforge
-   ```
+
+    ```console
+    $ brew install --cask mambaforge
+    ```
 
 3. Create a new environment using mamba (here with python 3.10) and activate it
-   ```console
-   $ mamba create -n pertpy-env python=3.10
-   $ mamba activate pertpy-env
-   ```
+
+    ```console
+    $ mamba create -n pertpy-env python=3.10
+    $ mamba activate pertpy-env
+    ```
 
 4. Clone the GitHub Repository
+
     ```console
-   $ git clone https://github.com/theislab/pertpy.git
-   ```
+    $ git clone https://github.com/theislab/pertpy.git
+    ```
 
 5. Go inside the pertpy folder and install pertpy
-    ```console
+   ```console
    $ cd pertpy
    $ pip install .
-   ```
-Now you're ready to use pertpy as usual within the environment (``import pertpy``).
+    ```
+    Now you're ready to use pertpy as usual within the environment (``import pertpy``).
+    ```
 
 [github repo]: https://github.com/theislab/pertpy
 [pip]: https://pip.pypa.io

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,8 +40,43 @@ Once you have a copy of the source, you can install it with:
 $ make install
 ```
 
+## Apple Silicon
+If you want to install and use pertpy on a machine with MacOS and M-Chip, the installation is slightly more complex.
+This is because pertpy depends on [scvi-tools], which can currently only run on Apple Silicon machines when installed
+using a native python version (due to a dependency on jax, which cannot be run via Rosetta).
+
+Follow these steps to install pertpy on an Apple Silicon machine (tested on a MacBook Pro with M1 chip and macOS 14.0):
+
+1. Install [Homebrew]
+
+2. Install Apple Silicon version of Mambaforge (If you already have Anaconda/Miniconda installed, make sure
+   having both mamba and conda won't cause conflicts)
+   ```console
+   $ brew install --cask mambaforge
+   ```
+
+3. Create a new environment using mamba (here with python 3.10) and activate it
+   ```console
+   $ mamba create -n pertpy-env python=3.10
+   $ mamba activate pertpy-env
+   ```
+
+4. Clone the GitHub Repository
+    ```console
+   $ git clone https://github.com/theislab/pertpy.git
+   ```
+
+5. Go inside the pertpy folder and install pertpy
+    ```console
+   $ cd pertpy
+   $ pip install .
+   ```
+Now you're ready to use pertpy as usual within the environment (``ìmport pertpy``).
+
 [github repo]: https://github.com/theislab/pertpy
 [pip]: https://pip.pypa.io
 [poetry]: https://python-poetry.org/
 [python installation guide]: http://docs.python-guide.org/en/latest/starting/installation/
 [tarball]: https://github.com/theislab/pertpy/tarball/master
+[scvi-tools]: https://docs.scvi-tools.org/en/latest/installation.html
+[Homebrew]: https://brew.sh/


### PR DESCRIPTION
**Description of changes**

Added installations instructions for Apple Silicon (macOs with M-Chips) users. Adapted the installation as well as the contributing guide.

**Technical details**

Pertpy uses scvi-tools, which only runs on Apple Silicon machines when installed via a native python version (see [here](https://docs.scvi-tools.org/en/latest/installation.html#apple-silicon)). Hence, also pertpy needs to be installed that way by macOs users with M-chips.