### PR TITLE
Move to new numpy.random.Generator 

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,11 +71,14 @@ Follow these steps to install pertpy on an Apple Silicon machine (tested on a Ma
     ```
 
 5. Go inside the pertpy folder and install pertpy
+
     ```console
     $ cd pertpy
     $ pip install .
     ```
+
     Now you're ready to use pertpy as usual within the environment (`import pertpy`).
+
     ```
 
     ```

--- a/pertpy/plot/_mixscape.py
+++ b/pertpy/plot/_mixscape.py
@@ -216,10 +216,11 @@ class MixscapePlot:
             p_copy._build()
             top_r = max(p_copy.layers[0].data["density"])
             perturbation_score["y_jitter"] = perturbation_score["pvec"]
-            perturbation_score.loc[perturbation_score[labels] == gd, "y_jitter"] = np.random.uniform(
+            rng = np.random.default_rng()
+            perturbation_score.loc[perturbation_score[labels] == gd, "y_jitter"] = rng.uniform(
                 low=0.001, high=top_r / 10, size=sum(perturbation_score[labels] == gd)
             )
-            perturbation_score.loc[perturbation_score[labels] == target_gene, "y_jitter"] = np.random.uniform(
+            perturbation_score.loc[perturbation_score[labels] == target_gene, "y_jitter"] = rng.uniform(
                 low=-top_r / 10, high=0, size=sum(perturbation_score[labels] == target_gene)
             )
             # If split_by is provided, split densities based on the split_by
@@ -265,18 +266,19 @@ class MixscapePlot:
             p_copy._build()
             top_r = max(p_copy.layers[0].data["density"])
             perturbation_score["y_jitter"] = perturbation_score["pvec"]
+            rng = np.random.default_rng()
             gd2 = list(
                 set(perturbation_score["mix"]).difference([f"{target_gene} NP", f"{target_gene} {perturbation_type}"])
             )[0]
-            perturbation_score.loc[perturbation_score["mix"] == gd2, "y_jitter"] = np.random.uniform(
+            perturbation_score.loc[perturbation_score["mix"] == gd2, "y_jitter"] = rng.uniform(
                 low=0.001, high=top_r / 10, size=sum(perturbation_score["mix"] == gd2)
             )
             perturbation_score.loc[
                 perturbation_score["mix"] == f"{target_gene} {perturbation_type}", "y_jitter"
-            ] = np.random.uniform(
+            ] = rng.uniform(
                 low=-top_r / 10, high=0, size=sum(perturbation_score["mix"] == f"{target_gene} {perturbation_type}")
             )
-            perturbation_score.loc[perturbation_score["mix"] == f"{target_gene} NP", "y_jitter"] = np.random.uniform(
+            perturbation_score.loc[perturbation_score["mix"] == f"{target_gene} NP", "y_jitter"] = rng.uniform(
                 low=-top_r / 10, high=0, size=sum(perturbation_score["mix"] == f"{target_gene} NP")
             )
             # If split_by is provided, split densities based on the split_by

--- a/pertpy/tools/_cinemaot.py
+++ b/pertpy/tools/_cinemaot.py
@@ -601,7 +601,8 @@ class Xi:
         # random shuffling of the data - reason to use random.choice is that
         # pd.sample(frac=1) uses the same randomizing algorithm
         len_x = len(self.x)
-        randomized_indices = np.random.choice(np.arange(len_x), len_x, replace=False)
+        rng = np.random.default_rng()
+        randomized_indices = rng.choice(np.arange(len_x), len_x, replace=False)
         randomized = [self.x[idx] for idx in randomized_indices]
         # same as pandas rank method 'first'
         rankdata = ss.rankdata(randomized, method="ordinal")

--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -347,7 +347,8 @@ class CompositionalModel2(ABC):
 
         # Set rng key if needed
         if rng_key is None:
-            rng_key = random.PRNGKey(np.random.randint(0, 10000))
+            rng = np.random.default_rng()
+            rng_key = random.PRNGKey(rng.integers(0, 10000))
             sample_adata.uns["scCODA_params"]["mcmc"]["rng_key"] = rng_key
         else:
             rng_key = random.PRNGKey(rng_key)

--- a/pertpy/tools/_coda/_sccoda.py
+++ b/pertpy/tools/_coda/_sccoda.py
@@ -212,14 +212,13 @@ class Sccoda(CompositionalModel2):
         beta_nobl_size = [D, P - 1]
 
         # Initial MCMC states
-        if rng_key is not None:
-            np.random.seed(rng_key)
+        rng = np.random.default_rng(seed=rng_key)
 
         sample_adata.uns["scCODA_params"]["mcmc"]["init_params"] = {
             "sigma_d": np.ones(dtype=np.float64, shape=sigma_size),
-            "b_offset": np.random.normal(0.0, 1.0, beta_nobl_size),
+            "b_offset": rng.normal(0.0, 1.0, beta_nobl_size),
             "ind_raw": np.zeros(dtype=np.float64, shape=beta_nobl_size),
-            "alpha": np.random.normal(0.0, 1.0, alpha_size),
+            "alpha": rng.normal(0.0, 1.0, alpha_size),
         }
 
         return sample_adata
@@ -378,7 +377,8 @@ class Sccoda(CompositionalModel2):
         ref_index = jnp.array(sample_adata.uns["scCODA_params"]["reference_index"])
 
         if rng_key is None:
-            rng_key = random.PRNGKey(np.random.randint(0, 10000))
+            rng = np.random.default_rng()
+            rng_key = random.PRNGKey(rng.integers(0, 10000))
 
         if use_posterior_predictive:
             posterior_predictive = Predictive(self.model, self.mcmc.get_samples())(

--- a/pertpy/tools/_coda/_tasccoda.py
+++ b/pertpy/tools/_coda/_tasccoda.py
@@ -345,16 +345,15 @@ class Tasccoda(CompositionalModel2):
         sample_adata.uns["scCODA_params"]["sslasso_pen_args"]["lambda_1_scaled"] = lambda_1
 
         # Initial MCMC states
-        if rng_key is not None:
-            np.random.seed(rng_key)
+        rng = np.random.default_rng(seed=rng_key)
 
         sample_adata.uns["scCODA_params"]["mcmc"]["init_params"] = {
             "a_0": np.ones(dtype=np.float64, shape=beta_nobl_size) * 1 / lambda_0,
-            "b_raw_0": np.random.normal(0.0, 1.0, beta_nobl_size),
+            "b_raw_0": rng.normal(0.0, 1.0, beta_nobl_size),
             "a_1": np.ones(dtype=np.float64, shape=beta_nobl_size) * 1 / lambda_1,
-            "b_raw_1": np.random.normal(0.0, 1.0, beta_nobl_size),
+            "b_raw_1": rng.normal(0.0, 1.0, beta_nobl_size),
             "theta": np.ones(dtype=np.float64, shape=1) * 0.5,
-            "alpha": np.random.normal(0.0, 1.0, alpha_size),
+            "alpha": rng.normal(0.0, 1.0, alpha_size),
         }
 
         return sample_adata
@@ -529,7 +528,8 @@ class Tasccoda(CompositionalModel2):
         ref_index = jnp.array(sample_adata.uns["scCODA_params"]["reference_index"])
 
         if rng_key is None:
-            rng_key = random.PRNGKey(np.random.randint(0, 10000))
+            rng = np.random.default_rng()
+            rng_key = random.PRNGKey(rng.integers(0, 10000))
 
         if use_posterior_predictive:
             posterior_predictive = Predictive(self.model, self.mcmc.get_samples())(

--- a/pertpy/tools/_distances/_distance_tests.py
+++ b/pertpy/tools/_distances/_distance_tests.py
@@ -148,7 +148,8 @@ class DistanceTest:
                 # Shuffle the labels of the groups
                 mask = adata.obs[groupby].isin([group, contrast])
                 labels = adata.obs[groupby].values[mask]
-                shuffled_labels = np.random.permutation(labels)
+                rng = np.random.default_rng()
+                shuffled_labels = rng.permutation(labels)
                 idx = shuffled_labels == group
 
                 X = embedding[mask][idx]  # shuffled group
@@ -245,7 +246,8 @@ class DistanceTest:
                 # Shuffle the labels of the groups
                 mask = adata.obs[groupby].isin([group, contrast])
                 labels = adata.obs[groupby].values[mask]
-                shuffled_labels = np.random.permutation(labels)
+                rng = np.random.default_rng()
+                shuffled_labels = rng.permutation(labels)
                 idx = shuffled_labels == group
 
                 precomputed_distance = precomputed_distances[group]

--- a/pertpy/tools/_scgen/_jax_scgen.py
+++ b/pertpy/tools/_scgen/_jax_scgen.py
@@ -110,8 +110,9 @@ class SCGEN(JaxTrainingMixin, BaseModelClass):
             ctrl_pred = adata_to_predict
 
         eq = min(ctrl_x.X.shape[0], stim_x.X.shape[0])
-        cd_ind = np.random.choice(range(ctrl_x.shape[0]), size=eq, replace=False)
-        stim_ind = np.random.choice(range(stim_x.shape[0]), size=eq, replace=False)
+        rng = np.random.default_rng()
+        cd_ind = rng.choice(range(ctrl_x.shape[0]), size=eq, replace=False)
+        stim_ind = rng.choice(range(stim_x.shape[0]), size=eq, replace=False)
         ctrl_adata = ctrl_x[cd_ind, :]
         stim_adata = stim_x[stim_ind, :]
 

--- a/pertpy/tools/_scgen/_utils.py
+++ b/pertpy/tools/_scgen/_utils.py
@@ -76,7 +76,8 @@ def balancer(
     for cls in class_names:
         class_index = np.array(adata.obs[cell_type_key] == cls)
         index_cls = np.nonzero(class_index)[0]
-        index_cls_r = index_cls[np.random.choice(len(index_cls), max_number)]
+        rng = np.random.default_rng()
+        index_cls_r = index_cls[rng.choice(len(index_cls), max_number)]
         index_all.append(index_cls_r)
 
     balanced_data = adata[np.concatenate(index_all)].copy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ select = [
     "UP",  # pyupgrade
     "RUF100",  # Report unused noqa directives
     "TCH",  # Typing imports
-    # "NPY",  # Numpy specific rules
+    "NPY",  # Numpy specific rules
     "PTH"  # Use pathlib
 ]
 ignore = [

--- a/tests/preprocessing/test_grna_assignment.py
+++ b/tests/preprocessing/test_grna_assignment.py
@@ -6,7 +6,7 @@ import pertpy as pt
 
 class TestGuideRnaProcessingAndPlotting:
     def make_test_adata(self):
-        np.random.seed(1)
+        # np.random.seed(1) TODO: Can we delete this? As far as I can see it's not used
         exp_matrix = np.array(
             [
                 [9, 0, 1, 0, 1, 0, 0],

--- a/tests/preprocessing/test_grna_assignment.py
+++ b/tests/preprocessing/test_grna_assignment.py
@@ -2,11 +2,12 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import pertpy as pt
+import pytest
 
 
 class TestGuideRnaProcessingAndPlotting:
-    def make_test_adata(self):
-        # np.random.seed(1) TODO: Can we delete this? As far as I can see it's not used
+    @pytest.fixture
+    def adata(self):
         exp_matrix = np.array(
             [
                 [9, 0, 1, 0, 1, 0, 0],
@@ -26,9 +27,7 @@ class TestGuideRnaProcessingAndPlotting:
         )
         return adata
 
-    def test_grna_threshold_assignment(self):
-        adata = self.make_test_adata()
-
+    def test_grna_threshold_assignment(self, adata):
         threshold = 5
         output_layer = "assigned_guides"
         assert output_layer not in adata.layers
@@ -38,9 +37,7 @@ class TestGuideRnaProcessingAndPlotting:
         assert output_layer in adata.layers
         assert np.all(np.logical_xor(adata.X < threshold, adata.layers[output_layer].A == 1))
 
-    def test_grna_max_assignment(self):
-        adata = self.make_test_adata()
-
+    def test_grna_max_assignment(self, adata):
         threshold = 5
         output_key = "assigned_guide"
         assert output_key not in adata.obs

--- a/tests/tools/_distances/test_distances.py
+++ b/tests/tools/_distances/test_distances.py
@@ -55,7 +55,8 @@ class TestDistances:
 
         # (M3) Triangle inequality (we just probe this for a few random triplets)
         for _i in range(10):
-            triplet = np.random.choice(df.index, size=3, replace=False)
+            rng = np.random.default_rng()
+            triplet = rng.choice(df.index, size=3, replace=False)
             assert df.loc[triplet[0], triplet[1]] + df.loc[triplet[1], triplet[2]] >= df.loc[triplet[0], triplet[2]]
 
     @mark.parametrize("distance", actual_distances + pseudo_distances)
@@ -94,8 +95,9 @@ class TestDistances:
     def test_distance_output_type(self, distance):
         # Test if distances are outputting floats
         Distance = pt.tl.Distance(distance, obsm_key="X_pca")
-        X = np.random.normal(size=(100, 10))
-        Y = np.random.normal(size=(100, 10))
+        rng = np.random.default_rng()
+        X = rng.normal(size=(100, 10))
+        Y = rng.normal(size=(100, 10))
         d = Distance(X, Y)
         assert isinstance(d, float)
 

--- a/tests/tools/_metadata/test_cell_line.py
+++ b/tests/tools/_metadata/test_cell_line.py
@@ -16,9 +16,9 @@ class TestMetaData:
 
     @pytest.fixture
     def adata(self) -> AnnData:
-        np.random.seed(1)
+        rng = np.random.default_rng(seed=1)
 
-        X = np.random.normal(0, 1, (NUM_CELLS, NUM_GENES))
+        X = rng.normal(0, 1, (NUM_CELLS, NUM_GENES))
         X = np.where(X < 0, 0, X)
 
         cell_line = {

--- a/tests/tools/_perturbation_space/test_simple_perturbation_space.py
+++ b/tests/tools/_perturbation_space/test_simple_perturbation_space.py
@@ -6,7 +6,8 @@ from anndata import AnnData
 
 
 def test_differential_response():
-    X = np.random.rand(10, 5)
+    rng = np.random.default_rng()
+    X = rng.random(size=(10, 5))
     obs = pd.DataFrame(
         {
             "perturbations": [
@@ -48,7 +49,8 @@ def test_differential_response():
 
 
 def test_pseudobulk_response():
-    X = np.random.rand(10, 5)
+    rng = np.random.default_rng()
+    X = rng.random(size=(10, 5))
     obs = pd.DataFrame(
         {
             "perturbations": [
@@ -168,7 +170,8 @@ def test_centroid_umap_response():
 
 def test_linear_operations():
     """Tests add/subtract and other linear operations."""
-    X = np.random.rand(10, 5)
+    rng = np.random.default_rng()
+    X = rng.random(size=(10, 5))
     obs = pd.DataFrame(
         {
             "perturbations": [

--- a/tests/tools/test_milo.py
+++ b/tests/tools/test_milo.py
@@ -110,16 +110,16 @@ class TestMilopy:
         self.milo.make_nhoods(adata)
 
         # Simulate experimental condition
-        np.random.seed(seed=42)
-        adata.obs["condition"] = np.random.choice(["ConditionA", "ConditionB"], size=adata.n_obs, p=[0.5, 0.5])
+        rng = np.random.default_rng(seed=42)
+        adata.obs["condition"] = rng.choice(["ConditionA", "ConditionB"], size=adata.n_obs, p=[0.5, 0.5])
         # we simulate differential abundance in NK cells
         DA_cells = adata.obs["louvain"] == "1"
-        adata.obs.loc[DA_cells, "condition"] = np.random.choice(
+        adata.obs.loc[DA_cells, "condition"] = rng.choice(
             ["ConditionA", "ConditionB"], size=sum(DA_cells), p=[0.2, 0.8]
         )
 
         # Simulate replicates
-        adata.obs["replicate"] = np.random.choice(["R1", "R2", "R3"], size=adata.n_obs)
+        adata.obs["replicate"] = rng.choice(["R1", "R2", "R3"], size=adata.n_obs)
         adata.obs["sample"] = adata.obs["replicate"] + adata.obs["condition"]
         milo_mdata = self.milo.count_nhoods(adata, sample_col="sample")
         return milo_mdata
@@ -179,16 +179,16 @@ class TestMilopy:
         self.milo.make_nhoods(adata)
 
         # Simulate experimental condition
-        np.random.seed(seed=42)
-        adata.obs["condition"] = np.random.choice(["ConditionA", "ConditionB"], size=adata.n_obs, p=[0.5, 0.5])
+        rng = np.random.default_rng(seed=42)
+        adata.obs["condition"] = rng.choice(["ConditionA", "ConditionB"], size=adata.n_obs, p=[0.5, 0.5])
         # we simulate differential abundance in NK cells
         DA_cells = adata.obs["louvain"] == "1"
-        adata.obs.loc[DA_cells, "condition"] = np.random.choice(
+        adata.obs.loc[DA_cells, "condition"] = rng.choice(
             ["ConditionA", "ConditionB"], size=sum(DA_cells), p=[0.2, 0.8]
         )
 
         # Simulate replicates
-        adata.obs["replicate"] = np.random.choice(["R1", "R2", "R3"], size=adata.n_obs)
+        adata.obs["replicate"] = rng.choice(["R1", "R2", "R3"], size=adata.n_obs)
         adata.obs["sample"] = adata.obs["replicate"] + adata.obs["condition"]
         milo_mdata = self.milo.count_nhoods(adata, sample_col="sample")
         return milo_mdata
@@ -208,7 +208,8 @@ class TestMilopy:
     def test_annotate_nhoods_continuous_correct_mean(self, annotate_nhoods_mdata):
         mdata = annotate_nhoods_mdata.copy()
         self.milo.annotate_nhoods_continuous(mdata, anno_col="S_score")
-        i = np.random.choice(np.arange(mdata["milo"].n_obs))
+        rng = np.random.default_rng(seed=42)
+        i = rng.choice(np.arange(mdata["milo"].n_obs))
         mean_val_nhood = mdata["rna"].obs[mdata["rna"].obsm["nhoods"][:, i].toarray() == 1]["S_score"].mean()
         assert mdata["milo"].var["nhood_S_score"][i] == pytest.approx(mean_val_nhood, 0.0001)
 
@@ -235,16 +236,16 @@ class TestMilopy:
         self.milo.make_nhoods(adata)
 
         # Simulate experimental condition
-        np.random.seed(seed=42)
-        adata.obs["condition"] = np.random.choice(["ConditionA", "ConditionB"], size=adata.n_obs, p=[0.2, 0.8])
+        rng = np.random.default_rng(seed=42)
+        adata.obs["condition"] = rng.choice(["ConditionA", "ConditionB"], size=adata.n_obs, p=[0.2, 0.8])
         # we simulate differential abundance in NK cells
         DA_cells = adata.obs["leiden"] == "1"
-        adata.obs.loc[DA_cells, "condition"] = np.random.choice(
+        adata.obs.loc[DA_cells, "condition"] = rng.choice(
             ["ConditionA", "ConditionB"], size=sum(DA_cells), p=[0.2, 0.8]
         )
 
         # Simulate replicates
-        adata.obs["replicate"] = np.random.choice(["R1", "R2", "R3"], size=adata.n_obs)
+        adata.obs["replicate"] = rng.choice(["R1", "R2", "R3"], size=adata.n_obs)
         adata.obs["sample"] = adata.obs["replicate"] + adata.obs["condition"]
         milo_mdata = self.milo.count_nhoods(adata, sample_col="sample")
         return milo_mdata

--- a/tests/tools/test_mixscape.py
+++ b/tests/tools/test_mixscape.py
@@ -19,14 +19,14 @@ accuracy_threshold = 0.8
 class TestMixscape:
     @fixture
     def adata(self):
-        np.random.seed(1)
+        rng = np.random.default_rng(seed=1)
         # generate not differentially expressed genes
         for i in range(num_not_de):
-            NT = np.random.normal(0, 1, num_cells_per_group)
+            NT = rng.normal(0, 1, num_cells_per_group)
             NT = np.where(NT < 0, 0, NT)
-            NP = np.random.normal(0, 1, num_cells_per_group)
+            NP = rng.normal(0, 1, num_cells_per_group)
             NP = np.where(NP < 0, 0, NP)
-            KO = np.random.normal(0, 1, num_cells_per_group)
+            KO = rng.normal(0, 1, num_cells_per_group)
             KO = np.where(KO < 0, 0, KO)
             gene_i = np.concatenate((NT, NP, KO))
             gene_i = np.expand_dims(gene_i, axis=1)
@@ -37,11 +37,11 @@ class TestMixscape:
 
         # generate differentially expressed genes
         for i in range(num_de):
-            NT = np.random.normal(i + 2, 0.5 + 0.05 * i, num_cells_per_group)
+            NT = rng.normal(i + 2, 0.5 + 0.05 * i, num_cells_per_group)
             NT = np.where(NT < 0, 0, NT)
-            NP = np.random.normal(i + 2, 0.5 + 0.05 * i, num_cells_per_group)
+            NP = rng.normal(i + 2, 0.5 + 0.05 * i, num_cells_per_group)
             NP = np.where(NP < 0, 0, NP)
-            KO = np.random.normal(i + 4, 0.5 + 0.1 * i, num_cells_per_group)
+            KO = rng.normal(i + 4, 0.5 + 0.1 * i, num_cells_per_group)
             KO = np.where(KO < 0, 0, KO)
             gene_i = np.concatenate((NT, NP, KO))
             gene_i = np.expand_dims(gene_i, axis=1)


### PR DESCRIPTION
**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [X] Referenced issue is linked (Fixes #355)

**Description of changes**

All occurrences of numpy Legacy Generator (RandomState) were replaced with the new `numpy.random.Generator`. Whenever an instance of the `numpy.random.Generator` was created, the recommended constructor `default_rng` was used.

**Technical details**

I tested that all legacy warnings have disappeared by including the numpy rules from ruff in the pre-commit checks.
