### PR TITLE
Speed up tests by subsampling

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,11 +71,14 @@ Follow these steps to install pertpy on an Apple Silicon machine (tested on a Ma
     ```
 
 5. Go inside the pertpy folder and install pertpy
+
     ```console
     $ cd pertpy
     $ pip install .
     ```
+
     Now you're ready to use pertpy as usual within the environment (`import pertpy`).
+
     ```
 
     ```

--- a/tests/tools/_coda/test_sccoda.py
+++ b/tests/tools/_coda/test_sccoda.py
@@ -3,8 +3,8 @@ from pathlib import Path
 import arviz as az
 import numpy as np
 import pandas as pd
-import scanpy as sc
 import pytest
+import scanpy as sc
 from mudata import MuData
 
 try:

--- a/tests/tools/_coda/test_sccoda.py
+++ b/tests/tools/_coda/test_sccoda.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import arviz as az
 import numpy as np
 import pandas as pd
+import scanpy as sc
 import pytest
 from mudata import MuData
 
@@ -22,6 +23,8 @@ class TestscCODA:
     @pytest.fixture
     def adata(self):
         cells = pt.dt.haber_2017_regions()
+        cells = sc.pp.subsample(cells, 0.1, copy=True)
+
         return cells
 
     def test_load(self, adata):

--- a/tests/tools/_coda/test_tasccoda.py
+++ b/tests/tools/_coda/test_tasccoda.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import numpy as np
+import scanpy as sc
 import pytest
 from mudata import MuData
 
@@ -20,6 +21,8 @@ class TesttascCODA:
     @pytest.fixture
     def smillie_adata(self):
         smillie_adata = pt.dt.smillie()
+        smillie_adata = sc.pp.subsample(smillie_adata, 0.1, copy=True)
+
         return smillie_adata
 
     def test_load(self, smillie_adata):
@@ -50,7 +53,7 @@ class TesttascCODA:
         assert "covariate_matrix" in mdata["coda"].obsm
         assert "sample_counts" in mdata["coda"].obsm
         assert isinstance(mdata["coda"].obsm["sample_counts"], np.ndarray)
-        assert np.sum(mdata["coda"].obsm["covariate_matrix"]) == 85
+        assert np.sum(mdata["coda"].obsm["covariate_matrix"]) == 8
 
     def test_run_nuts(self, smillie_adata):
         mdata = self.tasccoda.load(

--- a/tests/tools/_coda/test_tasccoda.py
+++ b/tests/tools/_coda/test_tasccoda.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 import numpy as np
-import scanpy as sc
 import pytest
+import scanpy as sc
 from mudata import MuData
 
 try:

--- a/tests/tools/test_cinemaot.py
+++ b/tests/tools/test_cinemaot.py
@@ -12,6 +12,7 @@ class TestCinemaot:
     @fixture
     def adata(self):
         adata = pt.dt.cinemaot_example()
+        adata = sc.pp.subsample(adata, 0.1, copy=True)
 
         return adata
 
@@ -74,8 +75,9 @@ class TestCinemaot:
             adata, de, pert_key="perturbation", control="No stimulation", label_list=None
         )
 
-        expect_num = 20
+        expect_num = 9
         eps = 7
         assert "ptb" in adata_pb.obs
         assert not np.isnan(np.sum(adata_pb.X))
+        print(adata_pb.shape)
         assert not np.abs(adata_pb.shape[0] - expect_num) >= eps


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [X] Referenced issue is linked (See #370)

**Description of changes**

In order to speed up testing, the data used for testing can be subsampled. Here, I examined all tests that use a pertpy dataloader and performed subsampling on the corresponding `AnnData` object.

To ensure that all tests still run, I had to make modifications to two elements that were hardcoded based on the size of the respective data object:
- In `test_tasccoda.test_prepare`: `assert np.sum(mdata["coda"].obsm["covariate_matrix"]) == 8` instead of `== 85`
- In `test_cinemaot.test_pseudobulk`: `expect_num = 9` instead of `expect_num = 20` (because `adata_pb.shape[0]` is 9 when subsampled by 10%)


_Note:_ `TestAugur`, which also relies on pertpy data, has not been modified yet. The tests will be rewritten as described in issue #380, and the subsampling will then be incorporated into the PR for that issue.


**Technical details**

I have confirmed that all tests still run successfully after subsampling. The following improvements in test running time were achieved (tested on my personal computer):

`test_sccoda`
- No subsampling: 43 sec 289 ms
- Subsampled by 10%: 38 sec 752 ms
- Subsampling by 5% or less resulted in an error in `test_credible_effects`, so I kept 10%

`test_tasccoda`
- No subsampling: 35 sec 578 ms
- Subsampled by 10%: 8 sec 828 ms

`test_cinemaot`
- No subsampling: 1 min 9 sec
- Subsampled by 10%: 8 sec 734 ms