### PR TITLE
Small bug fixes and docs improvements

### DIFF
--- a/pertpy/plot/_dialogue.py
+++ b/pertpy/plot/_dialogue.py
@@ -51,7 +51,8 @@ class DialoguePlot:
 
         return ax
 
-    def pairplot(self, adata: AnnData, celltype_key: str, color: str, sample_id: str, mcp: str = "mcp_0") -> PairGrid:
+    @staticmethod
+    def pairplot(adata: AnnData, celltype_key: str, color: str, sample_id: str, mcp: str = "mcp_0") -> PairGrid:
         """Generate a pairplot visualization for multi-cell perturbation (MCP) data.
 
         Computes the mean of a specified MCP feature (mcp) for each combination of sample and cell type,
@@ -75,10 +76,7 @@ class DialoguePlot:
             >>> dl = pt.tl.Dialogue(sample_id = "clinical.status", celltype_key = "cell.subtypes", \
                 n_counts_key = "nCount_RNA", n_mpcs = 3)
             >>> adata, mcps, ws, ct_subs = dl.calculate_multifactor_PMD(adata, normalize=True)
-            #>>> dl_pl=pt.pl.dl()
-            #>>> dl_pl.pairplot(adata=adata, celltype_key="cell.subtypes", color="gender", sample_id="clinical.status")
             >>> pt.pl.dl.pairplot(adata, celltype_key="cell.subtypes", color="gender", sample_id="clinical.status")
-            #TODO: Is self parameter there on purpose -> create DialoguePlot object first?
         """
         mean_mcps = adata.obs.groupby([sample_id, celltype_key])[mcp].mean()
         mean_mcps = mean_mcps.reset_index()

--- a/pertpy/plot/_scgen.py
+++ b/pertpy/plot/_scgen.py
@@ -43,6 +43,13 @@ class JaxscgenPlot:
             save: Specify if the plot should be saved or not.
             gene_list: list of gene names to be plotted.
             show: if `True`: will show to the plot after saving it.
+            top_100_genes: List of the top 100 differentially expressed genes. Specify if you want the top 100 DEGs to be assessed extra.
+            verbose: Specify if you want information to be printed while creating the plot, defaults to `False`.
+            legend: if `True`: plots a legend, defaults to `True`.
+            title: Set if you want the plot to display a title.
+            x_coeff: Offset to print the R^2 value in x-direction, defaults to 0.3.
+            y_coeff: Offset to print the R^2 value in y-direction, defaults to 0.8.
+            fontsize: Fontsize used for text in the plot, defaults to 14.
             **kwargs:
 
         Examples:
@@ -171,6 +178,13 @@ class JaxscgenPlot:
             save: Specify if the plot should be saved or not.
             gene_list: list of gene names to be plotted.
             show: if `True`: will show to the plot after saving it.
+            top_100_genes: List of the top 100 differentially expressed genes. Specify if you want the top 100 DEGs to be assessed extra.
+            legend: if `True`: plots a legend, defaults to `True`.
+            title: Set if you want the plot to display a title.
+            verbose: Specify if you want information to be printed while creating the plot, defaults to `False`.
+            x_coeff: Offset to print the R^2 value in x-direction, defaults to 0.3.
+            y_coeff: Offset to print the R^2 value in y-direction, defaults to 0.8.
+            fontsize: Fontsize used for text in the plot, defaults to 14.
         """
         import seaborn as sns
 

--- a/pertpy/tools/_perturbation_space/_perturbation_space.py
+++ b/pertpy/tools/_perturbation_space/_perturbation_space.py
@@ -61,7 +61,7 @@ class PerturbationSpace:
 
         if embedding_key is not None and embedding_key not in adata.obsm_keys():
             raise ValueError(
-                f"Reference key {reference_key} not found in {target_col}. {reference_key} must be in obs column {target_col}."
+                f"Embedding key {embedding_key} not found in obsm keys of the anndata."
             )
 
         if layer_key is not None and layer_key not in adata.layers.keys():
@@ -124,6 +124,7 @@ class PerturbationSpace:
         perturbations: Iterable[str],
         reference_key: str = "control",
         ensure_consistency: bool = False,
+        target_col: str = "perturbations",
     ):
         """Add perturbations linearly. Assumes input of size n_perts x dimensionality
 
@@ -132,6 +133,7 @@ class PerturbationSpace:
             perturbations: Perturbations to add.
             reference_key: perturbation source from which the perturbation summation starts.
             ensure_consistency: If True, runs differential expression on all data matrices to ensure consistency of linear space.
+            target_col: .obs column name that stores the label of the perturbation applied to each cell. Defaults to 'perturbations'.
 
         Examples:
             Example usage with PseudobulkSpace:
@@ -145,7 +147,7 @@ class PerturbationSpace:
         for perturbation in perturbations:
             if perturbation not in adata.obs_names:
                 raise ValueError(
-                    f"Perturbation {reference_key} not found in adata.obs_names. {reference_key} must be in adata.obs_names."
+                    f"Perturbation {perturbation} not found in adata.obs_names. {perturbation} must be in adata.obs_names."
                 )
             new_pert_name += perturbation + "+"
 
@@ -156,7 +158,7 @@ class PerturbationSpace:
                 "Run with ensure_consistency=True"
             )
         else:
-            adata = self.compute_control_diff(adata, copy=True, all_data=True)
+            adata = self.compute_control_diff(adata, copy=True, all_data=True, target_col=target_col)
 
         data: dict[str, np.array] = {}
 
@@ -223,6 +225,7 @@ class PerturbationSpace:
         perturbations: Iterable[str],
         reference_key: str = "control",
         ensure_consistency: bool = False,
+        target_col: str = "perturbations",
     ):
         """Subtract perturbations linearly. Assumes input of size n_perts x dimensionality
 
@@ -231,6 +234,7 @@ class PerturbationSpace:
             perturbations: Perturbations to subtract,
             reference_key: Perturbation source from which the perturbation subtraction starts
             ensure_consistency: If True, runs differential expression on all data matrices to ensure consistency of linear space.
+            target_col: .obs column name that stores the label of the perturbation applied to each cell. Defaults to 'perturbations'.
 
         Examples:
             Example usage with PseudobulkSpace:
@@ -244,7 +248,7 @@ class PerturbationSpace:
         for perturbation in perturbations:
             if perturbation not in adata.obs_names:
                 raise ValueError(
-                    f"Perturbation {reference_key} not found in adata.obs_names. {reference_key} must be in adata.obs_names."
+                    f"Perturbation {perturbation} not found in adata.obs_names. {perturbation} must be in adata.obs_names."
                 )
             new_pert_name += perturbation + "-"
 
@@ -255,7 +259,7 @@ class PerturbationSpace:
                 "Run with ensure_consistency=True"
             )
         else:
-            adata = self.compute_control_diff(adata, copy=True, all_data=True)
+            adata = self.compute_control_diff(adata, copy=True, all_data=True, target_col=target_col)
 
         data: dict[str, np.array] = {}
 

--- a/pertpy/tools/_perturbation_space/_perturbation_space.py
+++ b/pertpy/tools/_perturbation_space/_perturbation_space.py
@@ -60,9 +60,7 @@ class PerturbationSpace:
             )
 
         if embedding_key is not None and embedding_key not in adata.obsm_keys():
-            raise ValueError(
-                f"Embedding key {embedding_key} not found in obsm keys of the anndata."
-            )
+            raise ValueError(f"Embedding key {embedding_key} not found in obsm keys of the anndata.")
 
         if layer_key is not None and layer_key not in adata.layers.keys():
             raise ValueError(f"Layer {layer_key!r} does not exist in the anndata.")

--- a/pertpy/tools/_perturbation_space/_simple.py
+++ b/pertpy/tools/_perturbation_space/_simple.py
@@ -106,6 +106,7 @@ class PseudobulkSpace(PerturbationSpace):
             target_col: .obs column that stores the label of the perturbation applied to each cell.
             layer_key: If specified pseudobulk computation is done by using the specified layer. Otherwise, computation is done with .X
             embedding_key: `obsm` key of the AnnData embedding to use for computation. Defaults to the 'X' matrix otherwise.
+            **kwargs: Are passed to decoupler's get_pseuobulk.
 
         Examples:
             >>> import pertpy as pp
@@ -147,7 +148,7 @@ class KMeansSpace(ClusteringSpace):
         adata: AnnData,
         layer_key: str = None,
         embedding_key: str = None,
-        cluster_key: str = None,
+        cluster_key: str = "k-means",
         copy: bool = False,
         return_object: bool = False,
         **kwargs,
@@ -171,9 +172,6 @@ class KMeansSpace(ClusteringSpace):
         """
         if copy:
             adata = adata.copy()
-
-        if cluster_key is None:
-            cluster_key = "k-means"
 
         if layer_key is not None and embedding_key is not None:
             raise ValueError("Please, select just either layer or embedding for computation.")
@@ -210,7 +208,7 @@ class DBSCANSpace(ClusteringSpace):
         adata: AnnData,
         layer_key: str = None,
         embedding_key: str = None,
-        cluster_key: str = None,
+        cluster_key: str = "dbscan",
         copy: bool = True,
         return_object: bool = False,
         **kwargs,
@@ -221,9 +219,10 @@ class DBSCANSpace(ClusteringSpace):
             adata: Anndata object of size cells x genes
             layer_key: If specified and exists in the adata, the clustering is done by using it. Otherwise, clustering is done with .X
             embedding_key: if specified and exists in the adata, the clustering is done with that embedding. Otherwise, clustering is done with .X
-            cluster_key: name of the .obs column to store the cluster labels. Defaults to 'k-means'
+            cluster_key: name of the .obs column to store the cluster labels. Defaults to 'dbscan'
             copy: if True returns a new Anndata of same size with the new column; otherwise it updates the initial adata
             return_object: if True returns the clustering object
+            **kwargs: Are passed to sklearn's DBSCAN.
 
         Examples:
             >>> import pertpy as pt
@@ -233,9 +232,6 @@ class DBSCANSpace(ClusteringSpace):
         """
         if copy:
             adata = adata.copy()
-
-        if cluster_key is None:
-            cluster_key = "dbscan"
 
         if embedding_key is not None:
             if embedding_key not in adata.obsm_keys():


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**
-   [X] Documentation in `docs` is updated

**Description of changes**

Some small bug fixes and docs improvements which I noticed would be useful during the creation of the docs examples. I made the following changes:

- Changed `pt.pl.dl.pairplot` to a static method (and deleted the self parameter). Before, it was necessary to create a `DialoguePlot` object and then call the pairplot method using the created object. Now, the method can be called directly with `pt.pl.dl.pairplot` which matches the convention we have for creating plots so far. The example in the docs was updated as well.
- Fixed error message in `subtract` and `add` methods of `PerturbationSpace` object. Before, the error messages always printed that the reference_key is missing in adata.obs_names, although the test checks for the presence of the perturbations.
- Fixed error message for embedding_key in `compute_control_diff` of `PerturbationSpace`. Before, it printed that the reference key is missing instead of the embedding_key.
- Added target_col parameter in `add` and `subtract` methods of `PerturbationSpace` object. The reason for this is that the method `compute_control_diff` is called by `add` as well as `subtract` and if there’s no option to set target_col, it will always default to “perturbations” which would make it necessary to rename the column if it is not named that way in the adata by default. Since the default of the parameter is set to “perturbations” in `add` and `subtract`, nothing changes if the methods were already working with your data.
- Added docs parameter description for **kwargs for `DBSCANSpace.compute`and `PseudobulkSpace.compute`
- Set default values for cluster_key for `KMeansSpace.compute` and `DBSCANSpace.compute` directly in the method signature (to 'k-means' and 'dbscan' respectively). This saves checking if the parameter is none and, if so, setting it to the default value. Also, for DBSCAN, the docs claimed the default value is ‘k-means’, which I corrected to ‘dbscan’
- Added docs explanations for all parameters for `pt.pl.scg.reg_mean_plot` and `pt.pl.scg.reg_var_plot`
