### PR TITLE
Fixed set_fdr for tascCODA models

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -79,7 +79,6 @@ Follow these steps to install pertpy on an Apple Silicon machine (tested on a Ma
 
 Now you're ready to use pertpy as usual within the environment (`import pertpy`).
 
-
 [github repo]: https://github.com/theislab/pertpy
 [pip]: https://pip.pypa.io
 [poetry]: https://python-poetry.org/

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -77,11 +77,8 @@ Follow these steps to install pertpy on an Apple Silicon machine (tested on a Ma
     $ pip install .
     ```
 
-    Now you're ready to use pertpy as usual within the environment (`import pertpy`).
+Now you're ready to use pertpy as usual within the environment (`import pertpy`).
 
-    ```
-
-    ```
 
 [github repo]: https://github.com/theislab/pertpy
 [pip]: https://pip.pypa.io

--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -1050,7 +1050,6 @@ class CompositionalModel2(ABC):
             intercept_df, effect_df = self.summary_prepare(sample_adata, est_fdr, *args, **kwargs)  # type: ignore
         elif sample_adata.uns["scCODA_params"]["model_type"] == "tree_agg":
             intercept_df, effect_df, node_df = self.summary_prepare(sample_adata, est_fdr, *args, **kwargs)  # type: ignore
-            # Save node df in `sample_adata.uns`
             sample_adata.uns["scCODA_params"]["node_df"] = node_df
         else:
             raise ValueError("No valid model type!")

--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -1046,7 +1046,15 @@ class CompositionalModel2(ABC):
         if isinstance(data, AnnData):
             sample_adata = data
 
-        intercept_df, effect_df = self.summary_prepare(sample_adata, est_fdr, *args, **kwargs)  # type: ignore
+        if sample_adata.uns["scCODA_params"]["model_type"] == "classic":
+            intercept_df, effect_df = self.summary_prepare(sample_adata, est_fdr, *args, **kwargs)  # type: ignore
+        elif sample_adata.uns["scCODA_params"]["model_type"] == "tree_agg":
+            intercept_df, effect_df, node_df = self.summary_prepare(sample_adata, est_fdr, *args, **kwargs)  # type: ignore
+            # Save node df in `sample_adata.uns`
+            sample_adata.uns["scCODA_params"]["node_df"] = node_df
+        else:
+            raise ValueError("No valid model type!")
+
         sample_adata.varm["intercept_df"] = intercept_df
         for cov in effect_df.index.get_level_values("Covariate"):
             sample_adata.varm[f"effect_df_{cov}"] = effect_df.loc[cov, :]

--- a/pertpy/tools/_coda/_tasccoda.py
+++ b/pertpy/tools/_coda/_tasccoda.py
@@ -664,7 +664,6 @@ class Tasccoda(CompositionalModel2):
             >>> )
             >>> tasccoda.run_nuts(mdata, num_samples=1000, num_warmup=100, rng_key=42)
             >>> tasccoda.set_fdr(mdata, est_fdr=0.4)
-            #TODO: Not working (throws error, because too many values to unpack -> Correct set_fdr first)
         """
         return super().set_fdr(data, est_fdr, modality_key, *args, **kwargs)
 


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [X] Referenced issue is linked (Fixes issue #407)

**Description of changes**

Fix of the `set_fdr` method for tree_agg models (tascCODA models). Since the `summary_prepare` method returns three values for tree_agg models but the previous code in `set_fdr` accepted only two (which is correct in the case of a classical model), an error was thrown. This bug is easily fixed by differentiating between the two models and then either expect the `summary_prepare` method to return two or three values.
