### PR TITLE
Fix code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
                   MPLBACKEND: agg
                   PLATFORM: ${{ matrix.os }}
                   DISPLAY: :42
-              run: pytest -v --cov --color=yes
+              run: pytest -v --cov=pertpy --color=yes
 
             - name: Show coverage report
               run: coverage report -m

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
 
             - name: Show coverage report
               run: coverage report -m
-  
+
             - name: Upload coverage
               uses: codecov/codecov-action@v3
               with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
                   MPLBACKEND: agg
                   PLATFORM: ${{ matrix.os }}
                   DISPLAY: :42
-              run: pytest -v --cov=pertpy --color=yes
+              run: coverage run -m pytest -v --color=yes
 
             - name: Show coverage report
               run: coverage report -m

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,3 +56,6 @@ jobs:
 
             - name: Upload coverage
               uses: codecov/codecov-action@v3
+              with:
+                  fail_ci_if_error: true
+                  verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,9 @@ jobs:
                   DISPLAY: :42
               run: pytest -v --cov --color=yes
 
+            - name: Show coverage report
+              run: coverage report -m
+  
             - name: Upload coverage
               uses: codecov/codecov-action@v3
               with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,13 +1,16 @@
-comment: false
+codecov:
+    require_ci_to_pass: no
+
 coverage:
     status:
         project:
             default:
-                target: auto
-        patch:
-            default:
-                enabled: no
-    ignore:
-        - "test/"
-github_checks:
-    annotations: false
+                # Require 1% coverage, i.e., succeed as long as coverage collection works
+                target: 1
+        patch: false
+        changes: false
+
+comment:
+    layout: diff, flags, files
+    behavior: once
+    require_base: no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,19 +100,29 @@ doc = [
 ]
 test = [
     "pytest",
-    "pytest-cov",
+    "coverage",
 ]
 
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.envs.test]
+features = ["test"]
+[tool.hatch.envs.test.scripts]
+run = "pytest {args}"
+cov = [
+    "coverage run -m pytest",
+    "coverage report -m",
+]
+
 [tool.coverage.run]
+source_pkgs = ["pertpy"]
 omit = [
     "**/test_*.py",
 ]
 
 [tool.pytest.ini_options]
-testpaths = "pertpy/tests"
+testpaths = "tests"
 xfail_strict = true
 addopts = [
     "--import-mode=importlib",  # allow using test files with same name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,15 +106,6 @@ test = [
 [tool.hatch.version]
 source = "vcs"
 
-[tool.hatch.envs.test]
-features = ["test"]
-[tool.hatch.envs.test.scripts]
-run = "pytest {args}"
-cov = [
-    "coverage run -m pytest",
-    "coverage report -m",
-]
-
 [tool.coverage.run]
 source_pkgs = ["pertpy"]
 omit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ test = [
 source = "vcs"
 
 [tool.coverage.run]
-source = ["pertpy"]
 omit = [
     "**/test_*.py",
 ]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Test suite for the pertpy package."""


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] Fixes #428
-   [x] No tests necessary
-   [x] No doc changes necessary

**Description of changes**

- Changing things so CI fails when coverage collection failed (0%) or upload failed
- Switch to run `coverage` directly instead of using `pytest-cov`

**Technical details**

Using `pytest-cov` can sometimes cause problems since it initializes its machinery after pytest has started doing its thing. `coverage run` will work in those circumstances.

Of course that means that pytest can’t prevent adding the current working directory to PYTHONPATH unless the project uses the `src` layout. Experimentally switching the project to src layout worked, but I think that’s out of scope for this PR.

**Additional context**

<!-- Add any other context or screenshots here. -->
