### PR TITLE
optimising "from_scanpy" function

### DIFF
--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -1504,7 +1504,7 @@ def from_scanpy(
         #     if any(adata.obs.groupby(sample_identifier).nunique()[c] != 1):
         #         print(f"Covariate {c} has non-unique values! Skipping...")
         #         covariate_obs.remove(c)
-        temp_df = haber_cells.obs.groupby(sample_identifier).nunique()[covariate_obs]
+        temp_df = adata.obs.groupby(sample_identifier).nunique()[covariate_obs]
         covariate_obs = temp_df.columns[temp_df.nunique() == 1]
         covariate_df_obs = adata.obs.groupby(sample_identifier).first()[covariate_obs]
         covariate_df_ = pd.concat((covariate_df_, covariate_df_obs), axis=1)

--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -1474,7 +1474,8 @@ def from_scanpy(
         sample_identifier = [sample_identifier]
 
     if covariate_obs:
-        covariate_obs += [i for i in sample_identifier if i not in covariate_obs]
+        # covariate_obs += [i for i in sample_identifier if i not in covariate_obs]
+        covariate_obs = list(set(covariate_obs + sample_identifier))
     else:
         covariate_obs = sample_identifier  # type: ignore
 
@@ -1499,11 +1500,12 @@ def from_scanpy(
         covariate_df_ = pd.concat((covariate_df_, covariate_df_uns), axis=1)
 
     if covariate_obs is not None:
-        for c in covariate_obs:
-            if any(adata.obs.groupby(sample_identifier).nunique()[c] != 1):
-                print(f"Covariate {c} has non-unique values! Skipping...")
-                covariate_obs.remove(c)
-
+        # for c in covariate_obs:
+        #     if any(adata.obs.groupby(sample_identifier).nunique()[c] != 1):
+        #         print(f"Covariate {c} has non-unique values! Skipping...")
+        #         covariate_obs.remove(c)
+        temp_df = haber_cells.obs.groupby(sample_identifier).nunique()[covariate_obs]
+        covariate_obs = temp_df.columns[temp_df.nunique() == 1]
         covariate_df_obs = adata.obs.groupby(sample_identifier).first()[covariate_obs]
         covariate_df_ = pd.concat((covariate_df_, covariate_df_obs), axis=1)
 


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] Referenced issue is linked [isse: 438](https://github.com/theislab/pertpy/issues/438)
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**
Have removed "for" loop for optimising and even used set operations for curation of _covariate_obs_ list.

**Technical details**
Created a temp_df variable for storing the groupby generated data frame and then filtered the columns of the newly generated data frame to remove inconsistent covariate_obs.
Also `covariate_obs += [i for i in sample_identifier if i not in covariate_obs]` is changed into `covariate_obs = list(set(covariate_obs + sample_identifier))`
**Additional context**
Needed a test database where I can compare the speed.  I used a very small dataset, thus can't be tested properly.
<!-- Add any other context or screenshots here. -->
