### PR TITLE
DiscriminatorClassifier compatibility with sparse matrices

### DIFF
--- a/pertpy/tools/_perturbation_space/_discriminator_classifier.py
+++ b/pertpy/tools/_perturbation_space/_discriminator_classifier.py
@@ -276,7 +276,7 @@ class PLDataset(Dataset):
         self.pert_labels = adata.obs[label_col]
 
     def __len__(self):
-        return len(self.data)
+        return self.data.shape[0]
 
     def __getitem__(self, idx):
         """Returns a sample and corresponding perturbations applied (labels)"""


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**Description of changes**

When preparing (`load`) a dataset stored in a sparse matrix (e.g. Norman dataset) for processing with `DiscriminatorClassifierSpace`, an error is thrown:

<img width="814" alt="Bildschirmfoto 2023-12-05 um 13 10 15" src="https://github.com/theislab/pertpy/assets/93096564/89685694-6624-4960-9b87-3462830699bd">

This is due to our custom implementation of the dataset storing the data for training the NN: `PLDataset`. When calling `len` for a `PLDataset` object, we call `len(matrix)`, which throws the error above in case the matrix is sparse. By simply changing it to `matrix.shape[0]`, this problem is solved. The previous behavior is unaltered, since `a.shape[0] == len(a)`.
