### PR TITLE
CentroidSpace AnnData Annotations

### DIFF
--- a/pertpy/tools/_perturbation_space/_simple.py
+++ b/pertpy/tools/_perturbation_space/_simple.py
@@ -27,8 +27,8 @@ class CentroidSpace(PerturbationSpace):
             target_col: .obs column that stores the label of the perturbation applied to each cell.
             layer_key: If specified pseudobulk computation is done by using the specified layer. Otherwise, computation is done with .X
             embedding_key: `obsm` key of the AnnData embedding to use for computation. Defaults to the 'X' matrix otherwise.
-            keep_obs: .obs columns in the input AnnData to keep in the output pseudobulk AnnData. Only .obs columns with the same value for
-                each cell of one perturbation can be kept. Defaults to None.
+            keep_obs: Whether .obs columns in the input AnnData should be kept in the output pseudobulk AnnData. Only .obs columns with the same value for
+                each cell of one perturbation are kept. Defaults to True.
 
         Examples:
             Compute the centroids of a UMAP embedding of the papalexi_2021 dataset:

--- a/pertpy/tools/_perturbation_space/_simple.py
+++ b/pertpy/tools/_perturbation_space/_simple.py
@@ -18,6 +18,7 @@ class CentroidSpace(PerturbationSpace):
         target_col: str = "perturbations",
         layer_key: str = None,
         embedding_key: str = "X_umap",
+        keep_obs: str | list[str] = None,
     ) -> AnnData:  # type: ignore
         """Computes the centroids of a pre-computed embedding such as UMAP.
 
@@ -26,6 +27,8 @@ class CentroidSpace(PerturbationSpace):
             target_col: .obs column that stores the label of the perturbation applied to each cell.
             layer_key: If specified pseudobulk computation is done by using the specified layer. Otherwise, computation is done with .X
             embedding_key: `obsm` key of the AnnData embedding to use for computation. Defaults to the 'X' matrix otherwise.
+            keep_obs: .obs columns in the input AnnData to keep in the output pseudobulk AnnData. Only .obs columns with the same value for
+                each cell of one perturbation can be kept. Defaults to None.
 
         Examples:
             Compute the centroids of a UMAP embedding of the papalexi_2021 dataset:
@@ -59,6 +62,13 @@ class CentroidSpace(PerturbationSpace):
         if target_col not in adata.obs:
             raise ValueError(f"Obs {target_col!r} does not exist in the .obs attribute.")
 
+        if keep_obs is not None:
+            if isinstance(keep_obs, str):
+                keep_obs = [keep_obs]
+            for obs in keep_obs:
+                if obs not in adata.obs:
+                    raise ValueError(f"Obs {obs!r} does not exist in the .obs attribute.")
+
         grouped = adata.obs.groupby(target_col)
 
         if X is None:
@@ -84,6 +94,19 @@ class CentroidSpace(PerturbationSpace):
 
         ps_adata = AnnData(X=X)
         ps_adata.obs_names = index
+        ps_adata.obs[target_col] = index
+
+        if embedding_key is not None:
+            ps_adata.obsm[embedding_key] = X
+
+        if keep_obs is not None: # Save the values of the obs columns of interest in the ps_adata object
+            for obs_name in keep_obs:
+                for pert in index:
+                    obs_value = adata[adata.obs.perturbation_name == pert].obs[obs_name].unique()
+                    if len(obs_value) > 1:
+                        raise ValueError(f"Obs {obs_name!r} has more than one value for perturbation {pert!r}. "
+                                         f"You can only keep obs columns with an unambiguous value for each perturbation.")
+                    ps_adata.obs.loc[ps_adata.obs.index == pert, obs_name] = obs_value[0]
 
         return ps_adata
 

--- a/pertpy/tools/_perturbation_space/_simple.py
+++ b/pertpy/tools/_perturbation_space/_simple.py
@@ -99,7 +99,7 @@ class CentroidSpace(PerturbationSpace):
                 if not obs_df[obs_name].isnull().values.any():
                     mapping = {pert: obs_df.loc[pert][obs_name] for pert in index}
                     ps_adata.obs[obs_name] = ps_adata.obs[target_col].map(mapping)
-                
+
         return ps_adata
 
 

--- a/pertpy/tools/_perturbation_space/_simple.py
+++ b/pertpy/tools/_perturbation_space/_simple.py
@@ -99,13 +99,15 @@ class CentroidSpace(PerturbationSpace):
         if embedding_key is not None:
             ps_adata.obsm[embedding_key] = X
 
-        if keep_obs is not None: # Save the values of the obs columns of interest in the ps_adata object
+        if keep_obs is not None:  # Save the values of the obs columns of interest in the ps_adata object
             for obs_name in keep_obs:
                 for pert in index:
                     obs_value = adata[adata.obs.perturbation_name == pert].obs[obs_name].unique()
                     if len(obs_value) > 1:
-                        raise ValueError(f"Obs {obs_name!r} has more than one value for perturbation {pert!r}. "
-                                         f"You can only keep obs columns with an unambiguous value for each perturbation.")
+                        raise ValueError(
+                            f"Obs {obs_name!r} has more than one value for perturbation {pert!r}. "
+                            f"You can only keep obs columns with an unambiguous value for each perturbation."
+                        )
                     ps_adata.obs.loc[ps_adata.obs.index == pert, obs_name] = obs_value[0]
 
         return ps_adata


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [X] Documentation in `docs` is updated

**Description of changes**

`CentroidSpace` calculates the centroid for all cells of a given perturbation. The resulting AnnData object will have one row for each perturbation. The objective of this pull request is to enhance the annotation of the returned AnnData object, thereby simplifying its downstream usage. Specifically, the following modifications in the `CentroidSpace.compute` method have been made:

- I included the .obs column specified in the parameter`target_col` (the column containing perturbation annotations) as a .obs column in the output. Although perturbation information is also stored as an index in the returned adata, having it in .obs is useful, for instance, for the creation of a colored UMAP plot (see screenshot below).
- The X of the returned adata contains the coordinates for each centroid in the respective embedding (e.g., UMAP). I also store the values in X as an embedding in obsm, once again, to simplify processes such as the creation of a UMAP plot.
- I introduced the parameter `keep_obs` to the `compute` function, allowing users to specify .obs columns from the original adata that should be kept in the returned adata. This is useful when additional annotations are required for downstream processing, such as a pathway annotation for each perturbation.

**Example usage**

![Bildschirmfoto 2023-12-06 um 21 18 34](https://github.com/theislab/pertpy/assets/93096564/9bbe5977-e8e4-423d-ad35-32776149ca7a)
