### PR TITLE
Fix subsetting of milo.plot_da_beeswarm

### DIFF
--- a/pertpy/tools/_milo.py
+++ b/pertpy/tools/_milo.py
@@ -849,15 +849,15 @@ class Milo:
                 "mdata should be a MuData object with two slots: feature_key and 'milo'. Run 'milopy.count_nhoods(adata)' first."
             ) from None
 
-        if subset_nhoods is not None:
-            nhood_adata = nhood_adata[subset_nhoods]
-
         try:
             nhood_adata.obs[anno_col]
         except KeyError:
             raise RuntimeError(
                 f"Unable to find {anno_col} in mdata.uns['nhood_adata']. Run 'milopy.utils.annotate_nhoods(adata, anno_col)' first"
             ) from None
+
+        if subset_nhoods is not None:
+            nhood_adata = nhood_adata[nhood_adata.obs[anno_col].isin(subset_nhoods)]
 
         try:
             nhood_adata.obs["logFC"]


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [X] Referenced issue is linked (closes #457)

**Description of changes**

As described in the referenced issue, the subsetting in `milo.plot_da_beeswarm` currently triggers an error. Essentially, our goal is to have the ability to choose specific subgroups in `.obs` to plot. I fixed the issue almost exactly as suggested in the issue, correcting how the respective rows are selected from the AnnData.

**Example**
```
pt.pl.milo.da_beeswarm(mdata)
```
<img width="400" alt="Bildschirmfoto 2023-12-27 um 10 55 50" src="https://github.com/theislab/pertpy/assets/93096564/0afd87a2-c2cb-4cfb-a1f7-8420efa45ba5">

With the fix we now have:
```
milo.plot_da_beeswarm(mdata, subset_nhoods=['Oligo', 'Microglia'])
```
<img width="400" alt="Bildschirmfoto 2023-12-27 um 10 56 36" src="https://github.com/theislab/pertpy/assets/93096564/5504d7f3-2dd7-4724-8b0d-f28bcf5a361c">




