### PR TITLE
Bootstrap

### DIFF
--- a/tests/tools/_distances/test_distances.py
+++ b/tests/tools/_distances/test_distances.py
@@ -47,88 +47,126 @@ class TestDistances:
 
         return adata
 
+    # @mark.parametrize("distance", all_distances)
+    # def test_distance(self, adata, distance):
+    #     Distance = pt.tl.Distance(distance, obsm_key="X_pca")
+    #     df = Distance.pairwise(adata, groupby="perturbation", show_progressbar=True)
+
+    #     assert isinstance(df, DataFrame)
+
+    # @mark.parametrize("distance", actual_distances + semi_distances)
+    # def test_distance_axioms(self, adata, distance):
+    #     # This is equivalent to testing for a semimetric, defined as fulfilling all axioms except triangle inequality.
+    #     Distance = pt.tl.Distance(distance, obsm_key="X_pca")
+    #     df = Distance.pairwise(adata, groupby="perturbation", show_progressbar=True)
+
+    #     # (M1) Definiteness
+    #     assert all(np.diag(df.values) == 0)  # distance to self is 0
+
+    #     # (M2) Positivity
+    #     assert len(df) == np.sum(df.values == 0)  # distance to other is not 0 (TODO)
+    #     assert all(df.values.flatten() >= 0)  # distance is non-negative
+
+    #     # (M3) Symmetry
+    #     assert np.sum(df.values - df.values.T) == 0
+
+    # @mark.parametrize("distance", actual_distances)
+    # def test_triangle_inequality(self, adata, distance):
+    #     # Test if distances are well-defined in accordance with metric axioms
+    #     Distance = pt.tl.Distance(distance, obsm_key="X_pca")
+    #     df = Distance.pairwise(adata, groupby="perturbation", show_progressbar=True)
+
+    #     # (M4) Triangle inequality (we just probe this for a few random triplets)
+    #     for _i in range(10):
+    #         rng = np.random.default_rng()
+    #         triplet = rng.choice(df.index, size=3, replace=False)
+    #         assert df.loc[triplet[0], triplet[1]] + df.loc[triplet[1], triplet[2]] >= df.loc[triplet[0], triplet[2]]
+
+    # @mark.parametrize("distance", all_distances)
+    # def test_distance_layers(self, adata, distance):
+    #     Distance = pt.tl.Distance(distance, layer_key="lognorm")
+    #     df = Distance.pairwise(adata, groupby="perturbation")
+
+    #     assert isinstance(df, DataFrame)
+    #     assert df.columns.equals(df.index)
+    #     assert np.sum(df.values - df.values.T) == 0  # symmetry
+
+    # @mark.parametrize("distance", actual_distances + pseudo_counts_distances)
+    # def test_distance_counts(self, adata, distance):
+    #     Distance = pt.tl.Distance(distance, layer_key="counts")
+    #     df = Distance.pairwise(adata, groupby="perturbation")
+    #     assert isinstance(df, DataFrame)
+    #     assert df.columns.equals(df.index)
+    #     assert np.sum(df.values - df.values.T) == 0
+
+    # @mark.parametrize("distance", all_distances)
+    # def test_mutually_exclusive_keys(self, adata, distance):
+    #     with pytest.raises(ValueError):
+    #         _ = pt.tl.Distance(distance, layer_key="counts", obsm_key="X_pca")
+
+    # @mark.parametrize("distance", all_distances)
+    # def test_distance_output_type(self, distance):
+    #     # Test if distances are outputting floats
+    #     Distance = pt.tl.Distance(distance, obsm_key="X_pca")
+    #     rng = np.random.default_rng()
+    #     X = rng.normal(size=(100, 10))
+    #     Y = rng.normal(size=(100, 10))
+    #     d = Distance(X, Y)
+    #     assert isinstance(d, float)
+
+    # @mark.parametrize("distance", all_distances)
+    # def test_distance_pairwise(self, adata, distance):
+    #     # Test consistency of pairwise distance results
+    #     Distance = pt.tl.Distance(distance, obsm_key="X_pca")
+    #     df = Distance.pairwise(adata, groupby="perturbation")
+
+    #     assert isinstance(df, DataFrame)
+    #     assert df.columns.equals(df.index)
+    #     assert np.sum(df.values - df.values.T) == 0  # symmetry
+
+    # @mark.parametrize("distance", all_distances + onesided_only)
+    # def test_distance_onesided(self, adata, distance):
+    #     # Test consistency of one-sided distance results
+    #     Distance = pt.tl.Distance(distance, obsm_key="X_pca")
+    #     selected_group = adata.obs.perturbation.unique()[0]
+    #     df = Distance.onesided_distances(adata, groupby="perturbation", selected_group=selected_group)
+    #     assert isinstance(df, Series)
+    #     assert df.loc[selected_group] == 0  # distance to self is 0
+
+    #### whole thing bootstrapping
+
     @mark.parametrize("distance", all_distances)
-    def test_distance(self, adata, distance):
-        Distance = pt.tl.Distance(distance, obsm_key="X_pca")
-        df = Distance.pairwise(adata, groupby="perturbation", show_progressbar=True)
-
-        assert isinstance(df, DataFrame)
-
-    @mark.parametrize("distance", actual_distances + semi_distances)
-    def test_distance_axioms(self, adata, distance):
-        # This is equivalent to testing for a semimetric, defined as fulfilling all axioms except triangle inequality.
-        Distance = pt.tl.Distance(distance, obsm_key="X_pca")
-        df = Distance.pairwise(adata, groupby="perturbation", show_progressbar=True)
-
-        # (M1) Definiteness
-        assert all(np.diag(df.values) == 0)  # distance to self is 0
-
-        # (M2) Positivity
-        assert len(df) == np.sum(df.values == 0)  # distance to other is not 0 (TODO)
-        assert all(df.values.flatten() >= 0)  # distance is non-negative
-
-        # (M3) Symmetry
-        assert np.sum(df.values - df.values.T) == 0
-
-    @mark.parametrize("distance", actual_distances)
-    def test_triangle_inequality(self, adata, distance):
-        # Test if distances are well-defined in accordance with metric axioms
-        Distance = pt.tl.Distance(distance, obsm_key="X_pca")
-        df = Distance.pairwise(adata, groupby="perturbation", show_progressbar=True)
-
-        # (M4) Triangle inequality (we just probe this for a few random triplets)
-        for _i in range(10):
-            rng = np.random.default_rng()
-            triplet = rng.choice(df.index, size=3, replace=False)
-            assert df.loc[triplet[0], triplet[1]] + df.loc[triplet[1], triplet[2]] >= df.loc[triplet[0], triplet[2]]
-
-    @mark.parametrize("distance", all_distances)
-    def test_distance_layers(self, adata, distance):
-        Distance = pt.tl.Distance(distance, layer_key="lognorm")
-        df = Distance.pairwise(adata, groupby="perturbation")
-
-        assert isinstance(df, DataFrame)
-        assert df.columns.equals(df.index)
-        assert np.sum(df.values - df.values.T) == 0  # symmetry
-
-    @mark.parametrize("distance", actual_distances + pseudo_counts_distances)
-    def test_distance_counts(self, adata, distance):
-        Distance = pt.tl.Distance(distance, layer_key="counts")
-        df = Distance.pairwise(adata, groupby="perturbation")
-        assert isinstance(df, DataFrame)
-        assert df.columns.equals(df.index)
-        assert np.sum(df.values - df.values.T) == 0
-
-    @mark.parametrize("distance", all_distances)
-    def test_mutually_exclusive_keys(self, adata, distance):
-        with pytest.raises(ValueError):
-            _ = pt.tl.Distance(distance, layer_key="counts", obsm_key="X_pca")
-
-    @mark.parametrize("distance", all_distances)
-    def test_distance_output_type(self, distance):
+    def test_bootstrap_distance_output_type(self, distance):
         # Test if distances are outputting floats
         Distance = pt.tl.Distance(distance, obsm_key="X_pca")
         rng = np.random.default_rng()
         X = rng.normal(size=(100, 10))
         Y = rng.normal(size=(100, 10))
-        d = Distance(X, Y)
-        assert isinstance(d, float)
+        d = Distance.bootstrap(X, Y)
+        assert hasattr(d, "mean")
+        assert hasattr(d, "variance")
 
     @mark.parametrize("distance", all_distances)
-    def test_distance_pairwise(self, adata, distance):
+    def test_bootstrap_distance_pairwise(self, adata, distance):
         # Test consistency of pairwise distance results
         Distance = pt.tl.Distance(distance, obsm_key="X_pca")
-        df = Distance.pairwise(adata, groupby="perturbation")
+        bootstrap_output = Distance.pairwise(adata, groupby="perturbation", bootstrap=True)
+        assert isinstance(bootstrap_output, tuple)
 
-        assert isinstance(df, DataFrame)
-        assert df.columns.equals(df.index)
-        assert np.sum(df.values - df.values.T) == 0  # symmetry
+        mean = bootstrap_output[0]
+        var = bootstrap_output[1]
+
+        assert mean.columns.equals(mean.index)
+        assert np.sum(mean.values - mean.values.T) == 0  # symmetry
+        assert np.sum(var.values - var.values.T) == 0  # symmetry
 
     @mark.parametrize("distance", all_distances + onesided_only)
-    def test_distance_onesided(self, adata, distance):
+    def test_bootstrap_distance_onesided(self, adata, distance):
         # Test consistency of one-sided distance results
         Distance = pt.tl.Distance(distance, obsm_key="X_pca")
         selected_group = adata.obs.perturbation.unique()[0]
-        df = Distance.onesided_distances(adata, groupby="perturbation", selected_group=selected_group)
-        assert isinstance(df, Series)
-        assert df.loc[selected_group] == 0  # distance to self is 0
+        bootstrap_output = Distance.onesided_distances(
+            adata, groupby="perturbation", selected_group=selected_group, bootstrap=True
+        )
+
+        assert isinstance(bootstrap_output, tuple)

--- a/tests/tools/_distances/test_distances.py
+++ b/tests/tools/_distances/test_distances.py
@@ -47,93 +47,91 @@ class TestDistances:
 
         return adata
 
-    # @mark.parametrize("distance", all_distances)
-    # def test_distance(self, adata, distance):
-    #     Distance = pt.tl.Distance(distance, obsm_key="X_pca")
-    #     df = Distance.pairwise(adata, groupby="perturbation", show_progressbar=True)
+    @mark.parametrize("distance", all_distances)
+    def test_distance(self, adata, distance):
+        Distance = pt.tl.Distance(distance, obsm_key="X_pca")
+        df = Distance.pairwise(adata, groupby="perturbation", show_progressbar=True)
 
-    #     assert isinstance(df, DataFrame)
+        assert isinstance(df, DataFrame)
 
-    # @mark.parametrize("distance", actual_distances + semi_distances)
-    # def test_distance_axioms(self, adata, distance):
-    #     # This is equivalent to testing for a semimetric, defined as fulfilling all axioms except triangle inequality.
-    #     Distance = pt.tl.Distance(distance, obsm_key="X_pca")
-    #     df = Distance.pairwise(adata, groupby="perturbation", show_progressbar=True)
+    @mark.parametrize("distance", actual_distances + semi_distances)
+    def test_distance_axioms(self, adata, distance):
+        # This is equivalent to testing for a semimetric, defined as fulfilling all axioms except triangle inequality.
+        Distance = pt.tl.Distance(distance, obsm_key="X_pca")
+        df = Distance.pairwise(adata, groupby="perturbation", show_progressbar=True)
 
-    #     # (M1) Definiteness
-    #     assert all(np.diag(df.values) == 0)  # distance to self is 0
+        # (M1) Definiteness
+        assert all(np.diag(df.values) == 0)  # distance to self is 0
 
-    #     # (M2) Positivity
-    #     assert len(df) == np.sum(df.values == 0)  # distance to other is not 0 (TODO)
-    #     assert all(df.values.flatten() >= 0)  # distance is non-negative
+        # (M2) Positivity
+        assert len(df) == np.sum(df.values == 0)  # distance to other is not 0 (TODO)
+        assert all(df.values.flatten() >= 0)  # distance is non-negative
 
-    #     # (M3) Symmetry
-    #     assert np.sum(df.values - df.values.T) == 0
+        # (M3) Symmetry
+        assert np.sum(df.values - df.values.T) == 0
 
-    # @mark.parametrize("distance", actual_distances)
-    # def test_triangle_inequality(self, adata, distance):
-    #     # Test if distances are well-defined in accordance with metric axioms
-    #     Distance = pt.tl.Distance(distance, obsm_key="X_pca")
-    #     df = Distance.pairwise(adata, groupby="perturbation", show_progressbar=True)
+    @mark.parametrize("distance", actual_distances)
+    def test_triangle_inequality(self, adata, distance):
+        # Test if distances are well-defined in accordance with metric axioms
+        Distance = pt.tl.Distance(distance, obsm_key="X_pca")
+        df = Distance.pairwise(adata, groupby="perturbation", show_progressbar=True)
 
-    #     # (M4) Triangle inequality (we just probe this for a few random triplets)
-    #     for _i in range(10):
-    #         rng = np.random.default_rng()
-    #         triplet = rng.choice(df.index, size=3, replace=False)
-    #         assert df.loc[triplet[0], triplet[1]] + df.loc[triplet[1], triplet[2]] >= df.loc[triplet[0], triplet[2]]
+        # (M4) Triangle inequality (we just probe this for a few random triplets)
+        for _i in range(10):
+            rng = np.random.default_rng()
+            triplet = rng.choice(df.index, size=3, replace=False)
+            assert df.loc[triplet[0], triplet[1]] + df.loc[triplet[1], triplet[2]] >= df.loc[triplet[0], triplet[2]]
 
-    # @mark.parametrize("distance", all_distances)
-    # def test_distance_layers(self, adata, distance):
-    #     Distance = pt.tl.Distance(distance, layer_key="lognorm")
-    #     df = Distance.pairwise(adata, groupby="perturbation")
+    @mark.parametrize("distance", all_distances)
+    def test_distance_layers(self, adata, distance):
+        Distance = pt.tl.Distance(distance, layer_key="lognorm")
+        df = Distance.pairwise(adata, groupby="perturbation")
 
-    #     assert isinstance(df, DataFrame)
-    #     assert df.columns.equals(df.index)
-    #     assert np.sum(df.values - df.values.T) == 0  # symmetry
+        assert isinstance(df, DataFrame)
+        assert df.columns.equals(df.index)
+        assert np.sum(df.values - df.values.T) == 0  # symmetry
 
-    # @mark.parametrize("distance", actual_distances + pseudo_counts_distances)
-    # def test_distance_counts(self, adata, distance):
-    #     Distance = pt.tl.Distance(distance, layer_key="counts")
-    #     df = Distance.pairwise(adata, groupby="perturbation")
-    #     assert isinstance(df, DataFrame)
-    #     assert df.columns.equals(df.index)
-    #     assert np.sum(df.values - df.values.T) == 0
+    @mark.parametrize("distance", actual_distances + pseudo_counts_distances)
+    def test_distance_counts(self, adata, distance):
+        Distance = pt.tl.Distance(distance, layer_key="counts")
+        df = Distance.pairwise(adata, groupby="perturbation")
+        assert isinstance(df, DataFrame)
+        assert df.columns.equals(df.index)
+        assert np.sum(df.values - df.values.T) == 0
 
-    # @mark.parametrize("distance", all_distances)
-    # def test_mutually_exclusive_keys(self, adata, distance):
-    #     with pytest.raises(ValueError):
-    #         _ = pt.tl.Distance(distance, layer_key="counts", obsm_key="X_pca")
+    @mark.parametrize("distance", all_distances)
+    def test_mutually_exclusive_keys(self, adata, distance):
+        with pytest.raises(ValueError):
+            _ = pt.tl.Distance(distance, layer_key="counts", obsm_key="X_pca")
 
-    # @mark.parametrize("distance", all_distances)
-    # def test_distance_output_type(self, distance):
-    #     # Test if distances are outputting floats
-    #     Distance = pt.tl.Distance(distance, obsm_key="X_pca")
-    #     rng = np.random.default_rng()
-    #     X = rng.normal(size=(100, 10))
-    #     Y = rng.normal(size=(100, 10))
-    #     d = Distance(X, Y)
-    #     assert isinstance(d, float)
+    @mark.parametrize("distance", all_distances)
+    def test_distance_output_type(self, distance):
+        # Test if distances are outputting floats
+        Distance = pt.tl.Distance(distance, obsm_key="X_pca")
+        rng = np.random.default_rng()
+        X = rng.normal(size=(100, 10))
+        Y = rng.normal(size=(100, 10))
+        d = Distance(X, Y)
+        assert isinstance(d, float)
 
-    # @mark.parametrize("distance", all_distances)
-    # def test_distance_pairwise(self, adata, distance):
-    #     # Test consistency of pairwise distance results
-    #     Distance = pt.tl.Distance(distance, obsm_key="X_pca")
-    #     df = Distance.pairwise(adata, groupby="perturbation")
+    @mark.parametrize("distance", all_distances)
+    def test_distance_pairwise(self, adata, distance):
+        # Test consistency of pairwise distance results
+        Distance = pt.tl.Distance(distance, obsm_key="X_pca")
+        df = Distance.pairwise(adata, groupby="perturbation")
 
-    #     assert isinstance(df, DataFrame)
-    #     assert df.columns.equals(df.index)
-    #     assert np.sum(df.values - df.values.T) == 0  # symmetry
+        assert isinstance(df, DataFrame)
+        assert df.columns.equals(df.index)
+        assert np.sum(df.values - df.values.T) == 0  # symmetry
 
-    # @mark.parametrize("distance", all_distances + onesided_only)
-    # def test_distance_onesided(self, adata, distance):
-    #     # Test consistency of one-sided distance results
-    #     Distance = pt.tl.Distance(distance, obsm_key="X_pca")
-    #     selected_group = adata.obs.perturbation.unique()[0]
-    #     df = Distance.onesided_distances(adata, groupby="perturbation", selected_group=selected_group)
-    #     assert isinstance(df, Series)
-    #     assert df.loc[selected_group] == 0  # distance to self is 0
-
-    #### whole thing bootstrapping
+    @mark.parametrize("distance", all_distances + onesided_only)
+    def test_distance_onesided(self, adata, distance):
+        # Test consistency of one-sided distance results
+        Distance = pt.tl.Distance(distance, obsm_key="X_pca")
+        selected_group = adata.obs.perturbation.unique()[0]
+        df = Distance.onesided_distances(adata, groupby="perturbation", selected_group=selected_group)
+        assert isinstance(df, Series)
+        assert df.loc[selected_group] == 0  # distance to self is 0
 
     @mark.parametrize("distance", all_distances)
     def test_bootstrap_distance_output_type(self, distance):
@@ -142,7 +140,7 @@ class TestDistances:
         rng = np.random.default_rng()
         X = rng.normal(size=(100, 10))
         Y = rng.normal(size=(100, 10))
-        d = Distance.bootstrap(X, Y)
+        d = Distance.bootstrap(X, Y, n_bootstrap=10)
         assert hasattr(d, "mean")
         assert hasattr(d, "variance")
 
@@ -150,7 +148,7 @@ class TestDistances:
     def test_bootstrap_distance_pairwise(self, adata, distance):
         # Test consistency of pairwise distance results
         Distance = pt.tl.Distance(distance, obsm_key="X_pca")
-        bootstrap_output = Distance.pairwise(adata, groupby="perturbation", bootstrap=True)
+        bootstrap_output = Distance.pairwise(adata, groupby="perturbation", bootstrap=True, n_bootstrap=10)
         assert isinstance(bootstrap_output, tuple)
 
         mean = bootstrap_output[0]
@@ -166,7 +164,7 @@ class TestDistances:
         Distance = pt.tl.Distance(distance, obsm_key="X_pca")
         selected_group = adata.obs.perturbation.unique()[0]
         bootstrap_output = Distance.onesided_distances(
-            adata, groupby="perturbation", selected_group=selected_group, bootstrap=True
+            adata, groupby="perturbation", selected_group=selected_group, bootstrap=True, n_bootstrap=10
         )
 
         assert isinstance(bootstrap_output, tuple)


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] Referenced issue is linked
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**
Addresses issue #497.
This PR introduces convenience functionality for using (random sampling with replacement) bootstrapping towards error estimation of distances between perturbations.

For the user, no breaking changes are introduced. The changes visible are
- additional parameters `bootstrap: bool = False`, `n_bootstrap: int = 100`, `bootstrap_random_state: int = 0` in the methods `Distance.one_sided` and `Distance.pairwise`
- an additional method `Distance.bootstrap`, a bootsrapping analogon to `Distance.__call__`
<!-- Please state what you've changed and how it might affect the user. -->

**Technical details**

<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

**Additional context: Examples**

`__call__` vs `bootstrap`
```py
import pertpy as pt
import scanpy as sc
import matplotlib.pyplot as plt
from seaborn import clustermap

adata = pt.dt.distance_example()

dist = pt.tl.Distance("euclidean")

print(dist(X, Y))
print(dist.bootstrap(X, Y, n_bootstrap=100))
```

```
2.640588
MeanVar(mean=3.3500843, variance=0.06426364)
```

`onesided`
```py
import pertpy as pt
import scanpy as sc
import matplotlib.pyplot as plt
from seaborn import clustermap

adata = pt.dt.distance_example()

dist = pt.tl.Distance("euclidean")

dists_one = dist.onesided_distances(adata, groupby="perturbation", selected_group="control")
print(dists_one.head())

dists_one, vars_one = dist.onesided_distances(
    adata, groupby="perturbation", selected_group="control", bootstrap=True
)
print(dists_one.head())
print(vars_one.head())
```

```
perturbation
p-INTERGENIC393453     1.823859
p-sgELF1-2             1.992385
p-INTERGENIC216151     1.856206
p-INTERGENIC1144056    1.999334
p-sgELF1-5             2.132977

perturbation
p-INTERGENIC393453     2.194509
p-sgELF1-2             2.335306
p-INTERGENIC216151     2.192096
p-INTERGENIC1144056    2.310208
p-sgELF1-5             2.421595

perturbation
p-INTERGENIC393453     0.133328
p-sgELF1-2             0.150482
p-INTERGENIC216151     0.136785
p-INTERGENIC1144056    0.124505
p-sgELF1-5             0.158694
```

`pairwise`
```py
import pertpy as pt
import scanpy as sc
import matplotlib.pyplot as plt
from seaborn import clustermap

adata = pt.dt.distance_example()

dist = pt.tl.Distance("euclidean")

dists = dist.pairwise(adata, groupby="perturbation")

means, vars = dist.pairwise(adata, groupby="perturbation", bootstrap=True)

clustermap(dists, robust=True, figsize=(10, 10))
clustermap(means, robust=True, figsize=(10, 10))
clustermap(vars, robust=True, figsize=(10, 10))

```
![image](https://github.com/theislab/pertpy/assets/65244425/1f69255f-9fef-4ceb-970d-814dfc63296c)

![image](https://github.com/theislab/pertpy/assets/65244425/ffbb5fca-8a34-4139-a04d-312bff463d67)

![image](https://github.com/theislab/pertpy/assets/65244425/4ed15bca-41fc-4b2a-8987-c80254fed013)

<!-- Add any other context or screenshots here. -->
