### PR TITLE
Removed warnings when running Augur scatterplot

### DIFF
--- a/pertpy/tools/_augur.py
+++ b/pertpy/tools/_augur.py
@@ -235,7 +235,7 @@ class Augur:
                         random_state=random_state,
                     )
                 )
-            subsample = AnnData.concatenate(*label_subsamples, index_unique=None)
+            subsample = AnnData.concat(*label_subsamples, index_unique=None)
         else:
             subsample = sc.pp.subsample(adata[:, features], n_obs=subsample_size, copy=True, random_state=random_state)
 

--- a/pertpy/tools/_mixscape.py
+++ b/pertpy/tools/_mixscape.py
@@ -602,7 +602,7 @@ class Mixscape:
             )
             pl.tight_layout()
             _utils.savefig_or_show("mixscape_barplot", show=show, save=save)
-            
+
             return ax
 
     def plot_heatmap(  # pragma: no cover


### PR DESCRIPTION
WIP

Running example code from Augur plot (`scatterplot`) causes a lot of warnings being printed out:

`h_adata, h_results = ag_rfc.predict(loaded_data, subsample_size=20, n_threads=4)`:

`/fs/gpfs41/lv07/fileset03/home/g_mann/namsaraeva/Packages/pertpy/pertpy/tools/_augur.py:238: FutureWarning: Use anndata.concat instead of AnnData.concatenate, AnnData.concatenate is deprecated and will be removed in the future. See the tutorial for concat at: https://anndata.readthedocs.io/en/latest/concatenation.html
  subsample = AnnData.concatenate(*label_subsamples, index_unique=None)`

`/fs/home/namsaraeva/miniconda3/envs/pertpy/lib/python3.10/site-packages/sklearn/metrics/_scorer.py:548: FutureWarning: The needs_threshold and needs_proba parameter are deprecated in version 1.4 and will be removed in 1.6. You can either let response_method be None or set it to predict to preserve the same behaviour.`