### PR TITLE
Augur warnings

### DIFF
--- a/pertpy/tools/_augur.py
+++ b/pertpy/tools/_augur.py
@@ -12,6 +12,7 @@ import pandas as pd
 import scanpy as sc
 import statsmodels.api as sm
 from anndata import AnnData
+import anndata as ad
 from joblib import Parallel, delayed
 from rich import print
 from rich.progress import track
@@ -140,7 +141,7 @@ class Augur:
             # filter samples according to label
             if condition_label is not None and treatment_label is not None:
                 print(f"Filtering samples with {condition_label} and {treatment_label} labels.")
-                adata = anndata.concat(
+                adata = ad.concat(
                     adata[adata.obs["label"] == condition_label], adata[adata.obs["label"] == treatment_label]
                 )
             label_encoder = LabelEncoder()
@@ -235,7 +236,7 @@ class Augur:
                         random_state=random_state,
                     )
                 )
-            subsample = anndata.concat(*label_subsamples, index_unique=None)
+            subsample = ad.concat(*label_subsamples, index_unique=None)
         else:
             subsample = sc.pp.subsample(adata[:, features], n_obs=subsample_size, copy=True, random_state=random_state)
 

--- a/pertpy/tools/_augur.py
+++ b/pertpy/tools/_augur.py
@@ -140,7 +140,7 @@ class Augur:
             # filter samples according to label
             if condition_label is not None and treatment_label is not None:
                 print(f"Filtering samples with {condition_label} and {treatment_label} labels.")
-                adata = AnnData.concatenate(
+                adata = anndata.concat(
                     adata[adata.obs["label"] == condition_label], adata[adata.obs["label"] == treatment_label]
                 )
             label_encoder = LabelEncoder()
@@ -235,7 +235,7 @@ class Augur:
                         random_state=random_state,
                     )
                 )
-            subsample = AnnData.concat(*label_subsamples, index_unique=None)
+            subsample = anndata.concat(*label_subsamples, index_unique=None)
         else:
             subsample = sc.pp.subsample(adata[:, features], n_obs=subsample_size, copy=True, random_state=random_state)
 

--- a/pertpy/tools/_augur.py
+++ b/pertpy/tools/_augur.py
@@ -235,7 +235,7 @@ class Augur:
                         random_state=random_state,
                     )
                 )
-            subsample = AnnData.concatenate(*label_subsamples, index_unique=None)
+            subsample = AnnData.concat(*label_subsamples, index_unique=None)
         else:
             subsample = sc.pp.subsample(adata[:, features], n_obs=subsample_size, copy=True, random_state=random_state)
 

--- a/pertpy/tools/_augur.py
+++ b/pertpy/tools/_augur.py
@@ -6,13 +6,13 @@ from dataclasses import dataclass
 from math import floor, nan
 from typing import TYPE_CHECKING, Any, Literal
 
+import anndata as ad
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import scanpy as sc
 import statsmodels.api as sm
 from anndata import AnnData
-import anndata as ad
 from joblib import Parallel, delayed
 from rich import print
 from rich.progress import track

--- a/pertpy/tools/_mixscape.py
+++ b/pertpy/tools/_mixscape.py
@@ -602,7 +602,7 @@ class Mixscape:
             )
             pl.tight_layout()
             _utils.savefig_or_show("mixscape_barplot", show=show, save=save)
-            
+
             return ax
 
     def plot_heatmap(  # pragma: no cover


### PR DESCRIPTION
WIP

Running example code from Augur plot (`scatterplot`) causes a lot of warnings being printed out:

`h_adata, h_results = ag_rfc.predict(loaded_data, subsample_size=20, n_threads=4)`:

`/fs/gpfs41/lv07/fileset03/home/g_mann/namsaraeva/Packages/pertpy/pertpy/tools/_augur.py:238: FutureWarning: Use anndata.concat instead of AnnData.concatenate, AnnData.concatenate is deprecated and will be removed in the future. See the tutorial for concat at: https://anndata.readthedocs.io/en/latest/concatenation.html
  subsample = AnnData.concatenate(*label_subsamples, index_unique=None)`

`/fs/home/namsaraeva/miniconda3/envs/pertpy/lib/python3.10/site-packages/sklearn/metrics/_scorer.py:548: FutureWarning: The needs_threshold and needs_proba parameter are deprecated in version 1.4 and will be removed in 1.6. You can either let response_method be None or set it to predict to preserve the same behaviour.`