### PR TITLE
Pseudobulk improvements

### DIFF
--- a/pertpy/tools/_perturbation_space/_simple.py
+++ b/pertpy/tools/_perturbation_space/_simple.py
@@ -116,6 +116,7 @@ class PseudobulkSpace(PerturbationSpace):
         self,
         adata: AnnData,
         target_col: str = "perturbation",
+        groups_col: str = None,
         layer_key: str = None,
         embedding_key: str = None,
         **kwargs,
@@ -125,6 +126,8 @@ class PseudobulkSpace(PerturbationSpace):
         Args:
             adata: Anndata object of size cells x genes
             target_col: .obs column that stores the label of the perturbation applied to each cell.
+            groups_col: Optional .obs column that stores a grouping label to consider for pseudobulk computation.
+                The summarized expression per perturbation (target_col) and group (groups_col) is computed. Defaults to None.
             layer_key: If specified pseudobulk computation is done by using the specified layer. Otherwise, computation is done with .X
             embedding_key: `obsm` key of the AnnData embedding to use for computation. Defaults to the 'X' matrix otherwise.
             **kwargs: Are passed to decoupler's get_pseuobulk.
@@ -136,11 +139,8 @@ class PseudobulkSpace(PerturbationSpace):
             >>> import pertpy as pt
             >>> mdata = pt.dt.papalexi_2021()
             >>> ps = pt.tl.PseudobulkSpace()
-            >>> ps_adata = ps.compute(mdata["rna"], target_col="gene_target", groups_col="gene_target")
+            >>> ps_adata = ps.compute(mdata["rna"], target_col="gene_target")
         """
-        if "groups_col" not in kwargs:
-            kwargs["groups_col"] = "perturbation"
-
         if layer_key is not None and embedding_key is not None:
             raise ValueError("Please, select just either layer or embedding for computation.")
 
@@ -159,7 +159,8 @@ class PseudobulkSpace(PerturbationSpace):
                 adata_emb.obs = adata.obs
                 adata = adata_emb
 
-        ps_adata = dc.get_pseudobulk(adata, sample_col=target_col, layer=layer_key, **kwargs)  # type: ignore
+        adata.obs[target_col] = adata.obs[target_col].astype("category")
+        ps_adata = dc.get_pseudobulk(adata, sample_col=target_col, layer=layer_key, groups_col=groups_col, **kwargs)  # type: ignore
 
         ps_adata.obs[target_col] = ps_adata.obs[target_col].astype("category")
 


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [X] Referenced issue is linked (closes #501)
-   [X] Documentation in `docs` is updated

**Description of changes**

- Added a parameter explanation for the `groups_col` parameter. There are use cases where one might want to specify groups to consider in addition to the perturbation. That way, one can, for example, summarize perturbations for each cell type individually, so that the resulting pseudobulk object would have separate datapoints for pert1_celltype1, pert1_celltype2, and so on. However, the default setting for this parameter should be `None`, and the parameter should be explained in the docs.
- Deleted `groups_col` parameter from the docs example (previously, `groups_col` was set to the same value as `target_col`, which is useless since decoupler then internally sets groups_col to None again, see [code here](https://github.com/saezlab/decoupler-py/blob/f3bc59b48985d8aa361b78a5de2e8cac8cd031eb/decoupler/utils_anndata.py#L159)).
- Added cast for .obs column storing the perturbation labels to category type
