### PR TITLE
Feature/regression classifier

### DIFF
--- a/pertpy/tools/_perturbation_space/_discriminator_classifier.py
+++ b/pertpy/tools/_perturbation_space/_discriminator_classifier.py
@@ -24,8 +24,9 @@ class DiscriminatorClassifierSpace(PerturbationSpace):
     """Leveraging discriminator classifier. Fit a classifier (MLP or regression) to the data and take the feature space.
 
     You can specify what model to use: either a multilayer perceptron (MLP) or a logistic regression model.
-    By default, the MLP is used. After training, the penultimate MLP layer or the coefficients of the logistic regression
-    model are used as the feature space.
+    By default, the MLP is used. After training, the weights in the last MLP layer or the coefficients of the logistic
+    regression model are used as the feature space. Note that the MLP will result in one embedding per cell, while the
+    regression classifier will result in one embedding per perturbation.
 
     See here https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7289078/ (Dose-response analysis) and Sup 17-19.
     We use either the coefficients of the model for each perturbation as a feature or train a classifier example
@@ -167,7 +168,7 @@ class DiscriminatorClassifierSpace(PerturbationSpace):
         return self
 
     def train(self, max_epochs: int = None, val_epochs_check: int = 5, patience: int = 2):
-        """Trains and tests the neural network model defined in the load step.
+        """Trains and tests the model (MLP or logistic regression) defined in the load step.
 
         Args:
             max_epochs: Maximum number of epochs for training. Default to 40 for mlp and 1000 for regression.

--- a/pertpy/tools/_perturbation_space/_discriminator_classifier.py
+++ b/pertpy/tools/_perturbation_space/_discriminator_classifier.py
@@ -242,8 +242,9 @@ class DiscriminatorClassifierSpace(PerturbationSpace):
 
             # Save adata observations for embedding annotations
             for obs_name in self.adata_obs.columns:
-                if not obs_df[obs_name].isnull().values.any():
-                    pert_adata.obs[obs_name] = pert_adata.obs["perturbations"].map({pert: obs_df.loc[pert][obs_name] for pert in index})
+                if not self.adata_obs[obs_name].isnull().values.any():
+                    pert_adata.obs[obs_name] = pert_adata.obs["perturbations"].map(
+                        {pert: self.adata_obs.loc[pert][obs_name] for pert in self.adata_obs.index})
 
             return pert_adata
 

--- a/pertpy/tools/_perturbation_space/_discriminator_classifier.py
+++ b/pertpy/tools/_perturbation_space/_discriminator_classifier.py
@@ -192,7 +192,6 @@ class DiscriminatorClassifierSpace(PerturbationSpace):
             self.regression_scores = {}
 
             for perturbation in self.regression_labels.unique():
-                print(f"Training regression model for perturbation {perturbation}")
                 labels = np.where(self.regression_labels == perturbation, 1, 0)
                 X_train, X_test, y_train, y_test = train_test_split(self.regression_data, labels,
                                                                     test_size=self.test_split_size, stratify=labels)
@@ -219,7 +218,11 @@ class DiscriminatorClassifierSpace(PerturbationSpace):
             self.trainer.test(model=self.mlp, dataloaders=self.test_dataloader)
 
     def get_embeddings(self) -> AnnData:
-        """Obtain the embeddings of the data, i.e., the values in the last layer of the MLP.
+        """Obtain the embeddings of the data.
+
+         For the MLP, this corresponds to the values in the last layer of the MLP. You will get one embedding per cell,
+         so be aware that you might need to apply another perturbation space to aggregate the embeddings per perturbation.
+         For the regression model, this corresponds to the coefficients of the logistic regression model, with one embedding per perturbation.
 
         Returns:
             AnnData whose `X` attribute is the perturbation embedding and whose .obs['perturbations'] are the names of the perturbations.
@@ -267,8 +270,7 @@ class DiscriminatorClassifierSpace(PerturbationSpace):
         # which would cause errors in the downstream processing of the AnnData object (e.g. when plotting)
         pert_adata.obs = pert_adata.obs.drop("encoded_perturbations", axis=1)
 
-
-
+        return pert_adata
 
 class MLP(torch.nn.Module):
     """

--- a/tests/tools/_perturbation_space/test_discriminator_classifier.py
+++ b/tests/tools/_perturbation_space/test_discriminator_classifier.py
@@ -62,6 +62,8 @@ def test_mlp_discriminator_classifier(adata):
     np.testing.assert_allclose(results["asw"], 0.99, rtol=0.1)
 
 def test_regression_discriminator_classifier(adata):
+    # Compute the embeddings using the classifier
+    ps = pt.tl.DiscriminatorClassifierSpace("regression")
     classifier_ps = ps.load(adata)
     classifier_ps.train()
     pert_embeddings = classifier_ps.get_embeddings()

--- a/tests/tools/_perturbation_space/test_discriminator_classifier.py
+++ b/tests/tools/_perturbation_space/test_discriminator_classifier.py
@@ -1,10 +1,11 @@
 import numpy as np
 import pandas as pd
 import pertpy as pt
+import pytest
 from anndata import AnnData
 
-
-def test_discriminator_classifier():
+@pytest.fixture
+def adata():
     X = np.zeros((20, 5), dtype=np.float32)
 
     pert_index = [
@@ -42,10 +43,27 @@ def test_discriminator_classifier():
 
     adata = AnnData(X, obs=obs)
 
+    return adata
+
+def test_mlp_discriminator_classifier(adata):
     # Compute the embeddings using the classifier
-    ps = pt.tl.DiscriminatorClassifierSpace()
+    ps = pt.tl.DiscriminatorClassifierSpace("mlp")
     classifier_ps = ps.load(adata, hidden_dim=[128])
-    classifier_ps.train(max_epochs=5)
+    classifier_ps.train(max_epochs=2)
+    pert_embeddings = classifier_ps.get_embeddings()
+
+    # The embeddings should cluster in 3 perfects clusters since the perturbations are easily separable
+    ps = pt.tl.KMeansSpace()
+    adata = ps.compute(pert_embeddings, n_clusters=3, copy=True)
+    results = ps.evaluate_clustering(adata, true_label_col="perturbations", cluster_col="k-means")
+    np.testing.assert_equal(len(results), 3)
+    np.testing.assert_allclose(results["nmi"], 0.99, rtol=0.1)
+    np.testing.assert_allclose(results["ari"], 0.99, rtol=0.1)
+    np.testing.assert_allclose(results["asw"], 0.99, rtol=0.1)
+
+def test_regression_discriminator_classifier(adata):
+    classifier_ps = ps.load(adata)
+    classifier_ps.train()
     pert_embeddings = classifier_ps.get_embeddings()
 
     # The embeddings should cluster in 3 perfects clusters since the perturbations are easily separable

--- a/tests/tools/_perturbation_space/test_discriminator_classifier.py
+++ b/tests/tools/_perturbation_space/test_discriminator_classifier.py
@@ -46,7 +46,7 @@ def adata():
     return adata
 
 def test_mlp_discriminator_classifier(adata):
-    # Compute the embeddings using the classifier
+    # Compute the embeddings using the MLP classifier
     ps = pt.tl.DiscriminatorClassifierSpace("mlp")
     classifier_ps = ps.load(adata, hidden_dim=[128])
     classifier_ps.train(max_epochs=2)
@@ -62,17 +62,12 @@ def test_mlp_discriminator_classifier(adata):
     np.testing.assert_allclose(results["asw"], 0.99, rtol=0.1)
 
 def test_regression_discriminator_classifier(adata):
-    # Compute the embeddings using the classifier
+    # Compute the embeddings using the regression classifier
     ps = pt.tl.DiscriminatorClassifierSpace("regression")
     classifier_ps = ps.load(adata)
     classifier_ps.train()
     pert_embeddings = classifier_ps.get_embeddings()
 
-    # The embeddings should cluster in 3 perfects clusters since the perturbations are easily separable
-    ps = pt.tl.KMeansSpace()
-    adata = ps.compute(pert_embeddings, n_clusters=3, copy=True)
-    results = ps.evaluate_clustering(adata, true_label_col="perturbations", cluster_col="k-means")
-    np.testing.assert_equal(len(results), 3)
-    np.testing.assert_allclose(results["nmi"], 0.99, rtol=0.1)
-    np.testing.assert_allclose(results["ari"], 0.99, rtol=0.1)
-    np.testing.assert_allclose(results["asw"], 0.99, rtol=0.1)
+    assert pert_embeddings.shape == (3, 5)
+    # The classifier should be able to distinguish control and target2 from the respective other two classes
+    assert np.all(pert_embeddings.obs[pert_embeddings.obs["perturbations"].isin(["control", "target2"])]["classifier_score"].values == 1.0)

--- a/tests/tools/_perturbation_space/test_discriminator_classifier.py
+++ b/tests/tools/_perturbation_space/test_discriminator_classifier.py
@@ -62,6 +62,10 @@ def test_mlp_discriminator_classifier(adata):
     np.testing.assert_allclose(results["asw"], 0.99, rtol=0.1)
 
 def test_regression_discriminator_classifier(adata):
+    # Add a MoA annotation to the adata
+    adata.obs["MoA"] = ["Growth" if pert == "target1" else "Unknown" for pert in adata.obs["perturbations"]]
+    adata.obs["Partial Annotation"] = ["Anno1" if pert == "target2" else np.nan for pert in adata.obs["perturbations"]]
+
     # Compute the embeddings using the regression classifier
     ps = pt.tl.DiscriminatorClassifierSpace("regression")
     classifier_ps = ps.load(adata)
@@ -69,5 +73,7 @@ def test_regression_discriminator_classifier(adata):
     pert_embeddings = classifier_ps.get_embeddings()
 
     assert pert_embeddings.shape == (3, 5)
+    assert pert_embeddings.obs[pert_embeddings.obs["perturbations"] == "target1"]["MoA"].values == "Growth"
+    assert "Partial Annotation" not in pert_embeddings.obs_names
     # The classifier should be able to distinguish control and target2 from the respective other two classes
     assert np.all(pert_embeddings.obs[pert_embeddings.obs["perturbations"].isin(["control", "target2"])]["classifier_score"].values == 1.0)


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [X] Referenced issue is linked (closes #538)
-   [X] If you've fixed a bug or added code that should be tested, add tests!
-   [X] Documentation in `docs` is updated

**Description of changes**

- As an alternative to a multi-layer perceptron (MLP), the discriminator classifier now also supports logistic regression for embedding creation
- The model (MLP or regression) is defined when creating the `DiscriminatorClassifierSpace` object. By default, it's set to MLP, ensuring backward compatibility with the previous usage
- I decreased the number of epochs for the MLP test from 5 to 2. As a result, computing time decreases from 1min 15sec to 43sec on my local machine. 2 epochs are still enough for the MLP to learn how to separate the classes.
- Added and restructured the tests for `DiscriminatorClassifierSpace`: The adata is now provided via a fixture and is subsequently used by both the MLP and the regression classifier testing methods

**Technical details**

I tested the regression classifier implementation using the Norman dataset using the following code:

```
sc.pp.pca(adata, n_comps=30)
ps = pt.tl.DiscriminatorClassifierSpace("regression")
classifier_ps = ps.load(adata, embedding_key="X_pca", target_col="perturbation_name")
classifier_ps.train()
pert_embeddings = classifier_ps.get_embeddings()

sc.pp.neighbors(pert_embeddings, use_rep='X')
sc.tl.umap(pert_embeddings)
sc.pl.umap(pert_embeddings, color=['gene_programme'])
```
Which results in the following UMAP:
![umap](https://github.com/theislab/pertpy/assets/93096564/b356d964-e881-48f1-97b7-73740f0487bf)
