### PR TITLE
Compute method for MLPClassifierSpace

### DIFF
--- a/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
+++ b/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
@@ -165,7 +165,9 @@ class MLPClassifierSpace(PerturbationSpace):
             adata: AnnData object of size cells x genes
             target_col: .obs column that stores the perturbations. Defaults to "perturbations".
             layer_key: Layer in adata to use. Defaults to None.
-            hidden_dim: List of hidden layers of the neural network. For instance: [512, 256].
+            hidden_dim: List of number of neurons in each hidden layers of the neural network. For instance, [512, 256]
+                will create a neural network with two hidden layers, the first with 512 neurons and the second with 256 neurons.
+                Defaults to [512].
             dropout: Amount of dropout applied, constant for all layers. Defaults to 0.
             batch_norm: Whether to apply batch normalization. Defaults to True.
             batch_size: The batch size, i.e. the number of datapoints to use in one forward/backward pass. Defaults to 256.
@@ -185,9 +187,9 @@ class MLPClassifierSpace(PerturbationSpace):
 
         Examples:
             >>> import pertpy as pt
-            >>> adata = pt.dt.papalexi_2021()["rna"]
+            >>> adata = pt.dt.norman_2019()
             >>> dcs = pt.tl.MLPClassifierSpace()
-            >>> cell_embeddings = dcs.compute(adata, target_col="gene_target")
+            >>> cell_embeddings = dcs.compute(adata, target_col="perturbation_name")
         """
         if layer_key is not None and layer_key not in adata.obs.columns:
             raise ValueError(f"Layer key {layer_key} not found in adata.")

--- a/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
+++ b/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
@@ -249,7 +249,6 @@ class MLPClassifierSpace(PerturbationSpace):
         # Save adata observations for embedding annotations in get_embeddings
         self.adata_obs = adata.obs.reset_index(drop=True)
 
-        # Train the model
         self.trainer = pl.Trainer(
             min_epochs=1,
             max_epochs=max_epochs,

--- a/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
+++ b/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
@@ -148,8 +148,8 @@ class MLPClassifierSpace(PerturbationSpace):
         batch_size: int = 256,
         test_split_size: float = 0.2,
         validation_split_size: float = 0.25,
-        max_epochs: int = 40,
-        val_epochs_check: int = 5,
+        max_epochs: int = 20,
+        val_epochs_check: int = 2,
         patience: int = 2,
     ) -> AnnData:
         """Creates cell embeddings by training a MLP classifier model to distinguish between perturbations.
@@ -175,9 +175,10 @@ class MLPClassifierSpace(PerturbationSpace):
             validation_split_size: Fraction of data to put in the validation set of the resultant train set.
                 E.g. a test_split_size of 0.2 and a validation_split_size of 0.25 means that 25% of 80% of the data
                 will be used for validation. Defaults to 0.25.
-            max_epochs: Maximum number of epochs for training. Defaults to 40.
+            max_epochs: Maximum number of epochs for training. Defaults to 20.
             val_epochs_check: Test performance on validation dataset after every val_epochs_check training epochs.
-                Defaults to 5.
+                Note that this affects early stopping, as the model will be stopped if the validation performance does not
+                improve for patience epochs. Defaults to 2.
             patience: Number of validation performance checks without improvement, after which the early stopping flag
                 is activated and training is therefore stopped. Defaults to 2.
 

--- a/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
+++ b/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
@@ -148,10 +148,10 @@ class MLPClassifierSpace(PerturbationSpace):
         batch_size: int = 256,
         test_split_size: float = 0.2,
         validation_split_size: float = 0.25,
-            max_epochs: int = 40,
-            val_epochs_check: int = 5,
-            patience: int = 2
-    ) -> AnnData    :
+        max_epochs: int = 40,
+        val_epochs_check: int = 5,
+        patience: int = 2,
+    ) -> AnnData:
         """Creates cell embeddings by training a MLP classifier model to distinguish between perturbations.
 
         A model is created using the specified parameters (hidden_dim, dropout, batch_norm). Further parameters such as
@@ -290,15 +290,23 @@ class MLPClassifierSpace(PerturbationSpace):
 
         return pert_adata
 
-    def load(self, **kwargs):
-        raise  DeprecationError("The load method is deprecated and will be removed in the future. Please use the compute method instead.")
+    def load(self, adata, **kwargs):
+        """This method is deprecated and will be removed in the future. Please use the compute method instead."""
+        raise DeprecationWarning(
+            "The load method is deprecated and will be removed in the future. Please use the compute method instead."
+        )
 
     def train(self, **kwargs):
-        raise DeprecationError("The train method is deprecated and will be removed in the future. Please use the compute method instead.")
-
+        """This method is deprecated and will be removed in the future. Please use the compute method instead."""
+        raise DeprecationWarning(
+            "The train method is deprecated and will be removed in the future. Please use the compute method instead."
+        )
 
     def get_embeddings(self, **kwargs):
-        raise  DeprecationError("The get_embeddings method is deprecated and will be removed in the future. Please use the compute method instead.")
+        """This method is deprecated and will be removed in the future. Please use the compute method instead."""
+        raise DeprecationWarning(
+            "The get_embeddings method is deprecated and will be removed in the future. Please use the compute method instead."
+        )
 
 
 class MLP(torch.nn.Module):

--- a/tests/tools/_perturbation_space/test_discriminator_classifiers.py
+++ b/tests/tools/_perturbation_space/test_discriminator_classifiers.py
@@ -52,10 +52,8 @@ def adata():
 
 
 def test_mlp_classifier_space(adata):
-    ps = pt.tl.MLPClassifierSpace()
-    classifier_ps = ps.load(adata, hidden_dim=[128])
-    classifier_ps.train(max_epochs=2)
-    pert_embeddings = classifier_ps.get_embeddings()
+    classifier_ps = pt.tl.MLPClassifierSpace()
+    pert_embeddings = classifier_ps.compute(adata, hidden_dim=[128],max_epochs=2)
 
     # The embeddings should cluster in 3 perfects clusters since the perturbations are easily separable
     ps = pt.tl.KMeansSpace()

--- a/tests/tools/_perturbation_space/test_discriminator_classifiers.py
+++ b/tests/tools/_perturbation_space/test_discriminator_classifiers.py
@@ -53,7 +53,7 @@ def adata():
 
 def test_mlp_classifier_space(adata):
     classifier_ps = pt.tl.MLPClassifierSpace()
-    pert_embeddings = classifier_ps.compute(adata, hidden_dim=[128],max_epochs=2)
+    pert_embeddings = classifier_ps.compute(adata, hidden_dim=[128], max_epochs=2)
 
     # The embeddings should cluster in 3 perfects clusters since the perturbations are easily separable
     ps = pt.tl.KMeansSpace()


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [X] Referenced issue is linked (closes #562)
-   [X] If you've fixed a bug or added code that should be tested, add tests!
-   [X] Documentation in `docs` is updated

**Description of changes**

- Replaced three separate methods (`load`, `train`, and `get_embeddings`) in the `MLPClassifierSpace` with a single `compute` method. The motivation for this is to unify the API, aligning it with other perturbation space methods, which all feature a `compute` method.

- The `load`, `train`, and `get_embeddings` methods persist, however, they now trigger a `DeprecationWarning` when called that points users to the new `compute` method.