### PR TITLE
Silence pandas groupby() warning when running Augur predict

### DIFF
--- a/pertpy/tools/_augur.py
+++ b/pertpy/tools/_augur.py
@@ -774,6 +774,7 @@ class Augur:
             elif (
                 cell_type_subsample.obs.groupby(
                     ["cell_type", "label"],
+                    observed=True,
                 ).y_.count()
                 < subsample_size
             ).any():


### PR DESCRIPTION
When running Augur predict, I stumbled upon this warning: 

<img width="718" alt="  " src="https://github.com/theislab/pertpy/assets/99650244/daaa105c-7921-48ca-b7b3-1d0f75ef9977">

This should silence the warning.