### PR TITLE
Add drug annotation for enrichment

### DIFF
--- a/pertpy/metadata/_cell_line.py
+++ b/pertpy/metadata/_cell_line.py
@@ -30,6 +30,7 @@ class CellLine(MetaData):
 
         self.depmap = None
         self.cancerxgene = None
+        self.gene_annotation = None
         self.bulk_rna_sanger = None
         self.bulk_rna_broad = None
         self.proteomics = None
@@ -39,13 +40,13 @@ class CellLine(MetaData):
     def _download_cell_line(self, cell_line_source: Literal["DepMap", "Cancerrxgene"] = "DepMap") -> None:
         if cell_line_source == "DepMap":
             # Download cell line metadata from DepMap
-            # Source: https://depmap.org/portal/download/all/ (DepMap Public 22Q2)
-            depmap_cell_line_path = Path(settings.cachedir) / "depmap_info.csv"
+            # Source: https://depmap.org/portal/download/all/ (DepMap Public 23Q4)
+            depmap_cell_line_path = Path(settings.cachedir) / "depmap_23Q4_info.csv"
             if not Path(depmap_cell_line_path).exists():
                 print("[bold yellow]No DepMap metadata file found. Starting download now.")
                 _download(
-                    url="https://ndownloader.figshare.com/files/35020903",
-                    output_file_name="depmap_info.csv",
+                    url="https://ndownloader.figshare.com/files/43746708",
+                    output_file_name="depmap_23Q4_info.csv",
                     output_path=settings.cachedir,
                     block_size=4096,
                     is_zip=False,
@@ -202,7 +203,7 @@ class CellLine(MetaData):
         self,
         adata: AnnData,
         query_id: str = "DepMap_ID",
-        reference_id: str = "DepMap_ID",
+        reference_id: str = "ModelID",
         fetch: list[str] | None = None,
         cell_line_source: Literal["DepMap", "Cancerrxgene"] = "DepMap",
         verbosity: int | str = 5,
@@ -215,9 +216,9 @@ class CellLine(MetaData):
         Args:
             adata: The data object to annotate.
             query_id: The column of `.obs` with cell line information. Defaults to "DepMap_ID".
-            reference_id: The type of cell line identifier in the meta data, e.g. DepMap_ID, cell_line_name or stripped_cell_line_name.
+            reference_id: The type of cell line identifier in the meta data, e.g. ModelID, CellLineName	or StrippedCellLineName.
                           If fetching cell line metadata from Cancerrxgene, it is recommended to choose
-                          "stripped_cell_line_name". Defaults to "DepMap_ID".
+                          "stripped_cell_line_name". Defaults to "ModelID".
             fetch: The metadata to fetch. Defaults to None (=all).
             cell_line_source: The source of cell line metadata, DepMap or Cancerrxgene. Defaults to "DepMap".
             verbosity: The number of unmatched identifiers to print, can be either non-negative values or "all".
@@ -314,7 +315,7 @@ class CellLine(MetaData):
         else:
             raise ValueError(
                 f"The requested cell line type {reference_id} is currently unavailable in the database.\n"
-                "TRefer to the available reference identifier in the chosen database.\n"
+                "Refer to the available reference identifier in the chosen database.\n"
                 "DepMap_ID is compared by default.\n"
                 "Alternatively, create a `CellLineMetaData.lookup()` object to "
                 "obtain the available reference identifiers in the metadata."
@@ -612,6 +613,8 @@ class CellLine(MetaData):
             self._download_cell_line(cell_line_source="DepMap")
         if self.cancerxgene is None:
             self._download_cell_line(cell_line_source="Cancerrxgene")
+        if self.gene_annotation is None:
+            self._download_gene_annotation()
         if self.bulk_rna_broad is None:
             self._download_bulk_rna(cell_line_source="broad")
         if self.bulk_rna_sanger is None:

--- a/pertpy/metadata/_drug.py
+++ b/pertpy/metadata/_drug.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from collections import ChainMap
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import pandas as pd
 from rich import print
@@ -23,33 +23,62 @@ class Drug(MetaData):
 
     def __init__(self):
         self.chembl = None
+        self.dgidb = None
 
-    def _download_drug_annotation(self) -> None:
-        # Prepared in https://github.com/theislab/pertpy-datasets/blob/main/chembl_data.ipynb
-        chembl_path = Path(settings.cachedir) / "chembl.json"
-        if not Path(chembl_path).exists():
-            print("[bold yellow]No metadata file was found for chembl. Starting download now.")
-            _download(
-                url="https://figshare.com/ndownloader/files/43871718",
-                output_file_name="chembl.json",
-                output_path=settings.cachedir,
-                block_size=4096,
-                is_zip=False,
+    def _download_drug_annotation(
+        self,
+        source: Literal["chembl", "dgidb"] = "chembl",
+    ) -> None:
+        if source == "chembl" and self.chembl is None:
+            # Prepared in https://github.com/theislab/pertpy-datasets/blob/main/chembl_data.ipynb
+            chembl_path = Path(settings.cachedir) / "chembl.json"
+            if not Path(chembl_path).exists():
+                print("[bold yellow]No metadata file was found for chembl. Starting download now.")
+                _download(
+                    url="https://figshare.com/ndownloader/files/43871718",
+                    output_file_name="chembl.json",
+                    output_path=settings.cachedir,
+                    block_size=4096,
+                    is_zip=False,
+                )
+            with chembl_path.open() as file:
+                chembl_json = json.load(file)
+            self._chembl_json = chembl_json
+            targets = dict(ChainMap(*[chembl_json[cat] for cat in chembl_json]))
+            self.chembl = pd.DataFrame([{"Compound": k, "Targets": v} for k, v in targets.items()])
+            self.chembl.rename(columns={"Targets": "targets", "Compound": "compounds"}, inplace=True)
+        if source == "dgidb" and self.dgidb is None:
+            dgidb_path = Path(settings.cachedir) / "dgidb.tsv"
+            if not Path(dgidb_path).exists():
+                print("[bold yellow]No metadata file was found for dgidb. Starting download now.")
+                _download(
+                    url="https://www.dgidb.org/data/latest/interactions.tsv",
+                    output_file_name="dgidb.tsv",
+                    output_path=settings.cachedir,
+                    block_size=4096,
+                    is_zip=False,
+                )
+            self.dgidb_df = pd.read_table(dgidb_path)
+            self.dgidb = self.dgidb_df.groupby("drug_claim_name")["gene_claim_name"].apply(list).reset_index()
+            self.dgidb.rename(
+                columns={"gene_claim_name": "targets", "drug_claim_name": "compounds"},
+                inplace=True,
             )
-        with chembl_path.open() as file:
-            chembl_json = json.load(file)
-        self._chembl_json = chembl_json
-        targets = dict(ChainMap(*[chembl_json[cat] for cat in chembl_json]))
-        self.chembl = pd.DataFrame([{"Compound": k, "Targets": v} for k, v in targets.items()])
-        self.chembl.rename(columns={"Targets": "targets", "Compound": "compounds"}, inplace=True)
+            self.dgidb_dict = self.dgidb.set_index("compounds")["targets"].to_dict()
 
-    def annotate(self, adata: AnnData, copy: bool = False) -> AnnData:
+    def annotate(
+        self,
+        adata: AnnData,
+        source: Literal["chembl", "dgidb"] = "chembl",
+        copy: bool = False,
+    ) -> AnnData:
         """Annotates genes by their involvement in applied drugs.
 
         Genes need to be in HGNC format.
 
         Args:
             adata: AnnData object containing log-normalised data.
+            source: Source of the metadata, chembl or dgidb. Defaults to chembl.
             copy: Determines whether a copy of the `adata` is returned. Defaults to False.
 
         Returns:
@@ -58,10 +87,15 @@ class Drug(MetaData):
         if copy:
             adata = adata.copy()
 
-        if self.chembl is None:
-            self._download_drug_annotation()
+        self._download_drug_annotation(source)
 
-        exploded_df = self.chembl.explode("targets")
+        interaction = None
+        if source == "chembl":
+            interaction = self.chembl
+        else:
+            interaction = self.dgidb
+
+        exploded_df = interaction.explode("targets")
 
         gene_compound_dict = (
             exploded_df.groupby("targets")["compounds"]
@@ -77,16 +111,18 @@ class Drug(MetaData):
         """Generate LookUp object for Drug.
 
         The LookUp object provides an overview of the metadata to annotate.
-        annotate_moa function has a corresponding lookup function in the LookUp object,
-        where users can search the query_ids and targets in the metadata.
+        annotate function has a corresponding lookup function in the LookUp object,
+        where users can search the compound and targets in the metadata.
 
         Returns:
-            Returns a LookUp object specific for MoA annotation.
+            Returns a LookUp object specific for drug annotation.
         """
         if self.chembl is None:
             self._download_drug_annotation()
+        if self.dgidb is None:
+            self._download_drug_annotation(source="dgidb")
 
         return LookUp(
-            type="moa",
-            transfer_metadata=[self.chembl],
+            type="drug",
+            transfer_metadata=[self.chembl, self.dgidb_df],
         )

--- a/pertpy/metadata/_drug.py
+++ b/pertpy/metadata/_drug.py
@@ -22,6 +22,9 @@ class Drug(MetaData):
     """Utilities to fetch metadata for drug studies."""
 
     def __init__(self):
+        self.chembl = None
+
+    def _download_drug_annotation(self) -> None:
         # Prepared in https://github.com/theislab/pertpy-datasets/blob/main/chembl_data.ipynb
         chembl_path = Path(settings.cachedir) / "chembl.json"
         if not Path(chembl_path).exists():
@@ -55,6 +58,9 @@ class Drug(MetaData):
         if copy:
             adata = adata.copy()
 
+        if self.chembl is None:
+            self._download_drug_annotation()
+
         exploded_df = self.chembl.explode("targets")
 
         gene_compound_dict = (
@@ -77,6 +83,9 @@ class Drug(MetaData):
         Returns:
             Returns a LookUp object specific for MoA annotation.
         """
+        if self.chembl is None:
+            self._download_drug_annotation()
+
         return LookUp(
             type="moa",
             transfer_metadata=[self.chembl],

--- a/pertpy/metadata/_look_up.py
+++ b/pertpy/metadata/_look_up.py
@@ -49,19 +49,19 @@ class LookUp:
             depmap_data = {
                 "n_cell_line": len(self.cell_line_meta.index),
                 "n_metadata": len(self.cell_line_meta.columns),
-                "cell_line": self.cell_line_meta.DepMap_ID.values,
+                "cell_line": self.cell_line_meta.ModelID.values,
                 "metadata": self.cell_line_meta.columns.values,
                 "reference_id": [
-                    "DepMap_ID",
-                    "cell_line_name",
-                    "stripped_cell_line_name",
+                    "ModelID",
+                    "CellLineName",
+                    "StrippedCellLineName",
                     "CCLE_Name",
                 ],
-                "reference_id_example": "DepMap_ID: ACH-000016 | cell_line_name: SLR 21 | stripped_cell_line_name: SLR21 | CCLE_Name: SLR21_KIDNEY",
+                "reference_id_example": "ModelID: ACH-000001 | CellLineName: NIH:OVCAR-3 | StrippedCellLineName: NIHOVCAR3 | CCLEName: NIHOVCAR3_OVARY",
                 "default_parameter": {
                     "cell_line_source": "DepMap",
                     "query_id": "DepMap_ID",
-                    "reference_id": "DepMap_ID",
+                    "reference_id": "ModelID",
                     "fetch": "None",
                 },
             }
@@ -233,16 +233,16 @@ class LookUp:
     def available_cell_lines(
         self,
         cell_line_source: Literal["DepMap", "Cancerrxgene"] = "DepMap",
-        reference_id: str = "DepMap_ID",
+        reference_id: str = "ModelID",
         query_id_list: Sequence[str] | None = None,
     ) -> None:
         """A brief summary of cell line metadata.
 
         Args:
             cell_line_source: the source of cell line annotation, DepMap or Cancerrxgene. Defaults to "DepMap".
-            reference_id: The type of cell line identifier in the meta data, e.g. DepMap_ID, cell_line_name or
-                stripped_cell_line_name. If fetch cell line metadata from Cancerrxgene, it is recommended to choose
-                "stripped_cell_line_name". Defaults to "DepMap_ID".
+            reference_id: The type of cell line identifier in the meta data, e.g. ModelID, CellLineName	or StrippedCellLineName.
+                If fetch cell line metadata from Cancerrxgene, it is recommended to choose
+                "stripped_cell_line_name". Defaults to "ModelID".
             query_id_list: Unique cell line identifiers to test the number of matched ids present in the
                 metadata. If set to None, the query of metadata identifiers will be disabled. Defaults to None.
         """
@@ -258,7 +258,7 @@ class LookUp:
                     )
                 not_matched_identifiers = list(set(query_id_list) - set(self.cell_line_meta[reference_id]))
             else:
-                if reference_id == "DepMap_ID":
+                if reference_id == "ModelID":
                     reference_id = "stripped_cell_line_name"
                 if reference_id not in self.cl_cancer_project_meta.columns:
                     raise ValueError(

--- a/pertpy/metadata/_moa.py
+++ b/pertpy/metadata/_moa.py
@@ -21,6 +21,9 @@ class Moa(MetaData):
     """Utilities to fetch metadata for mechanism of action studies."""
 
     def __init__(self):
+        self.clue = None
+
+    def _download_clue(self) -> None:
         clue_path = Path(settings.cachedir) / "repurposing_drugs_20200324.txt"
         if not Path(clue_path).exists():
             print("[bold yellow]No metadata file was found for clue. Starting download now.")
@@ -63,6 +66,9 @@ class Moa(MetaData):
 
         if query_id not in adata.obs.columns:
             raise ValueError(f"The requested query_id {query_id} is not in `adata.obs`.\n" "Please check again.")
+
+        if self.clue is None:
+            self._download_clue()
 
         identifier_num_all = len(adata.obs[query_id].unique())
         not_matched_identifiers = list(set(adata.obs[query_id].str.lower()) - set(self.clue["pert_iname"].str.lower()))
@@ -114,6 +120,9 @@ class Moa(MetaData):
         Returns:
             Returns a LookUp object specific for MoA annotation.
         """
+        if self.clue is None:
+            self._download_clue()
+
         return LookUp(
             type="moa",
             transfer_metadata=[self.clue],

--- a/tests/metadata/test_cell_line.py
+++ b/tests/metadata/test_cell_line.py
@@ -23,19 +23,14 @@ class TestMetaData:
 
         obs = pd.DataFrame(
             {
-                "DepMap_ID": ["ACH-000016", "ACH-000049", "ACH-001208", "ACH-000956"]
-                * NUM_CELLS_PER_ID,
+                "DepMap_ID": ["ACH-000016", "ACH-000049", "ACH-001208", "ACH-000956"] * NUM_CELLS_PER_ID,
                 "perturbation": ["Midostaurin"] * NUM_CELLS_PER_ID * 4,
             },
             index=[str(i) for i in range(NUM_GENES)],
         )
 
         var_data = {"gene_name": [f"gene{i}" for i in range(1, NUM_GENES + 1)]}
-        var = (
-            pd.DataFrame(var_data)
-            .set_index("gene_name", drop=False)
-            .rename_axis("index")
-        )
+        var = pd.DataFrame(var_data).set_index("gene_name", drop=False).rename_axis("index")
 
         X = sparse.csr_matrix(X)
         adata = anndata.AnnData(X=X, obs=obs, var=var)
@@ -44,9 +39,7 @@ class TestMetaData:
 
     def test_cell_line_annotation(self, adata):
         self.pt_metadata.annotate(adata=adata)
-        assert (
-            len(adata.obs.columns) == len(self.pt_metadata.depmap.columns) + 1
-        )  # due to the perturbation column
+        assert len(adata.obs.columns) == len(self.pt_metadata.depmap.columns) + 1  # due to the perturbation column
         stripped_cell_line_name = ["SLR21", "HEKTE", "TK10", "22RV1"] * NUM_CELLS_PER_ID
         assert stripped_cell_line_name == list(adata.obs["StrippedCellLineName"])
 
@@ -57,9 +50,7 @@ class TestMetaData:
 
     def test_protein_expression_annotation(self, adata):
         self.pt_metadata.annotate(adata)
-        self.pt_metadata.annotate_protein_expression(
-            adata, query_id="StrippedCellLineName"
-        )
+        self.pt_metadata.annotate_protein_expression(adata, query_id="StrippedCellLineName")
 
         assert len(adata.obsm) == 1
         assert adata.obsm["proteomics_protein_intensity"].shape == (
@@ -69,9 +60,7 @@ class TestMetaData:
 
     def test_bulk_rna_expression_annotation(self, adata):
         self.pt_metadata.annotate(adata)
-        self.pt_metadata.annotate_bulk_rna(
-            adata, query_id="DepMap_ID", cell_line_source="broad"
-        )
+        self.pt_metadata.annotate_bulk_rna(adata, query_id="DepMap_ID", cell_line_source="broad")
 
         assert len(adata.obsm) == 1
         assert adata.obsm["bulk_rna_broad"].shape == (

--- a/tests/metadata/test_cell_line.py
+++ b/tests/metadata/test_cell_line.py
@@ -23,14 +23,19 @@ class TestMetaData:
 
         obs = pd.DataFrame(
             {
-                "DepMap_ID": ["ACH-000016", "ACH-000049", "ACH-001208", "ACH-000956"] * NUM_CELLS_PER_ID,
+                "DepMap_ID": ["ACH-000016", "ACH-000049", "ACH-001208", "ACH-000956"]
+                * NUM_CELLS_PER_ID,
                 "perturbation": ["Midostaurin"] * NUM_CELLS_PER_ID * 4,
             },
             index=[str(i) for i in range(NUM_GENES)],
         )
 
         var_data = {"gene_name": [f"gene{i}" for i in range(1, NUM_GENES + 1)]}
-        var = pd.DataFrame(var_data).set_index("gene_name", drop=False).rename_axis("index")
+        var = (
+            pd.DataFrame(var_data)
+            .set_index("gene_name", drop=False)
+            .rename_axis("index")
+        )
 
         X = sparse.csr_matrix(X)
         adata = anndata.AnnData(X=X, obs=obs, var=var)
@@ -39,19 +44,22 @@ class TestMetaData:
 
     def test_cell_line_annotation(self, adata):
         self.pt_metadata.annotate(adata=adata)
-        assert len(adata.obs.columns) == len(self.pt_metadata.depmap.columns) + 1  # due to the perturbation column
-        assert set(self.pt_metadata.depmap.columns).issubset(adata.obs)
+        assert (
+            len(adata.obs.columns) == len(self.pt_metadata.depmap.columns) + 1
+        )  # due to the perturbation column
         stripped_cell_line_name = ["SLR21", "HEKTE", "TK10", "22RV1"] * NUM_CELLS_PER_ID
-        assert stripped_cell_line_name == list(adata.obs["stripped_cell_line_name"])
+        assert stripped_cell_line_name == list(adata.obs["StrippedCellLineName"])
 
     def test_gdsc_annotation(self, adata):
         self.pt_metadata.annotate(adata)
-        self.pt_metadata.annotate_from_gdsc(adata, query_id="stripped_cell_line_name")
+        self.pt_metadata.annotate_from_gdsc(adata, query_id="StrippedCellLineName")
         assert "ln_ic50" in adata.obs
 
     def test_protein_expression_annotation(self, adata):
         self.pt_metadata.annotate(adata)
-        self.pt_metadata.annotate_protein_expression(adata, query_id="stripped_cell_line_name")
+        self.pt_metadata.annotate_protein_expression(
+            adata, query_id="StrippedCellLineName"
+        )
 
         assert len(adata.obsm) == 1
         assert adata.obsm["proteomics_protein_intensity"].shape == (
@@ -61,7 +69,9 @@ class TestMetaData:
 
     def test_bulk_rna_expression_annotation(self, adata):
         self.pt_metadata.annotate(adata)
-        self.pt_metadata.annotate_bulk_rna(adata, query_id="DepMap_ID", cell_line_source="broad")
+        self.pt_metadata.annotate_bulk_rna(
+            adata, query_id="DepMap_ID", cell_line_source="broad"
+        )
 
         assert len(adata.obsm) == 1
         assert adata.obsm["bulk_rna_broad"].shape == (
@@ -69,7 +79,7 @@ class TestMetaData:
             self.pt_metadata.bulk_rna_broad.shape[1],
         )
 
-        self.pt_metadata.annotate_bulk_rna(adata, query_id="stripped_cell_line_name")
+        self.pt_metadata.annotate_bulk_rna(adata, query_id="StrippedCellLineName")
 
         assert len(adata.obsm) == 2
         assert adata.obsm["bulk_rna_sanger"].shape == (

--- a/tests/metadata/test_drug.py
+++ b/tests/metadata/test_drug.py
@@ -18,7 +18,12 @@ class TestDrug:
 
         return adata
 
-    def test_moa_annotation(self, adata):
+    def test_moa_annotation_chembl(self, adata):
         self.pt_drug.annotate(adata=adata)
         assert {"compounds"}.issubset(adata.var.columns)
         assert "CHEMBL1693" in adata.var["compounds"]["SLC6A2"]
+
+    def test_moa_annotation_dgidb(self, adata):
+        self.pt_drug.annotate(adata=adata, source="dgidb")
+        assert {"compounds"}.issubset(adata.var.columns)
+        assert "AMITIFADINE" in adata.var["compounds"]["SLC6A2"]


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] Referenced issue is linked #483 
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**
- Add dgidb for drug annotation
- Fix bug and add new functions for lookup object with type `drug`
- The dgidb metadata is saved for enrichment function. A small example:
```
adata = sc.datasets.pbmc3k_processed()
pt_drug = pt.md.Drug()
pt_drug.annotate(adata, source="dgidb")
pt_enricher = pt.tl.Enrichment()
pt_enricher.score(
    adata, targets = pt_drug.dgidb_dict
)
# pt_drug.dgidb_dict saves the target and compunds in a unnested dictionary.
```
- However currently `pt.tl.Enrichment.plot_dotplot` doesnt accept targets in the unnested format (gives error if an unnested dict is given). I think it makes sense to go with nested dict to filter further categories. For this the user can play with the metadata
```
interaction = pt_drug.dgidb_df
interaction["interaction_type"] = interaction["interaction_type"].fillna("Unknown/Other")
nested_dict = (
    interaction.groupby("interaction_type")
    .apply(
        lambda x: x.groupby("drug_claim_name")["gene_claim_name"].apply(list).to_dict()
    )
    .to_dict()
)
```
I didnt save it into Drug() because there are multiple possible categories to choose including `approved`, `immunotherapy`,	`anti_neoplastic`, `interaction_type`. 

Do you probably have any suggestions how to interact with enrichment funtion better?
- 
<!-- Please state what you've changed and how it might affect the user. -->

**Technical details**

<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

**Additional context**

<!-- Add any other context or screenshots here. -->
