### PR TITLE
Add sciplex-GxE dataloader

### DIFF
--- a/pertpy/data/__init__.py
+++ b/pertpy/data/__init__.py
@@ -38,6 +38,7 @@ from pertpy.data._datasets import (
     schraivogel_2020_tap_screen_chr8,
     schraivogel_2020_tap_screen_chr11,
     sciplex3_raw,
+    sciplex_gxe1,
     shifrut_2018,
     smillie_2019,
     srivatsan_2020_sciplex2,

--- a/pertpy/data/_datasets.py
+++ b/pertpy/data/_datasets.py
@@ -1513,3 +1513,30 @@ def combosciplex() -> AnnData:  # pragma: no cover
     adata = sc.read_h5ad(output_file_path)
 
     return adata
+
+
+def sciplex_gxe1() -> AnnData:  # pragma: no cover
+    """sci-Plex-GxE combined chemical and genetic profiling of A172 dCas9-KRAB cells 
+    genetically perturbed for HPRT1 or mismtach repair genes exposed to 6-thioguanine and temozolomide, 
+    respectively, and A172 dCas9-SunTag cells genetically perturbed for HPRT1 exposed to 6-thioguanine.
+
+    References:
+        McFaline-Figueroa JL et al., Trapnell C. Multiplex single-cell chemical genomics reveals 
+        the kinase dependence of the response to targeted therapy. Cell Genomics. 2024 Volume 4, Issue 2.
+        doi: 10.1016/j.xgen.2023.100487
+
+    Returns:
+        :class:`~anndata.AnnData` object of the dataset.
+    """
+    output_file_name = "sciPlexGxE_1_GSM7056148.h5ad"
+    output_file_path = settings.datasetdir / output_file_name
+    if not Path(output_file_path).exists():
+        _download(
+            url="https://figshare.com/ndownloader/files/45372454",
+            output_file_name=output_file_name,
+            output_path=settings.datasetdir,
+            is_zip=False,
+        )
+    adata = sc.read_h5ad(output_file_path)
+
+    return adata

--- a/pertpy/data/_datasets.py
+++ b/pertpy/data/_datasets.py
@@ -1516,12 +1516,12 @@ def combosciplex() -> AnnData:  # pragma: no cover
 
 
 def sciplex_gxe1() -> AnnData:  # pragma: no cover
-    """sci-Plex-GxE combined chemical and genetic profiling of A172 dCas9-KRAB cells 
-    genetically perturbed for HPRT1 or mismtach repair genes exposed to 6-thioguanine and temozolomide, 
+    """sci-Plex-GxE combined chemical and genetic profiling of A172 dCas9-KRAB cells
+    genetically perturbed for HPRT1 or mismtach repair genes exposed to 6-thioguanine and temozolomide,
     respectively, and A172 dCas9-SunTag cells genetically perturbed for HPRT1 exposed to 6-thioguanine.
 
     References:
-        McFaline-Figueroa JL et al., Trapnell C. Multiplex single-cell chemical genomics reveals 
+        McFaline-Figueroa JL et al., Trapnell C. Multiplex single-cell chemical genomics reveals
         the kinase dependence of the response to targeted therapy. Cell Genomics. 2024 Volume 4, Issue 2.
         doi: 10.1016/j.xgen.2023.100487
 


### PR DESCRIPTION
Added a dataloader for the sciPlexGxE HPRT1 & MMR GxE screens from https://www.cell.com/cell-genomics/fulltext/S2666-979X(23)00339-7. 

The second screen is too heavy to be added yet (ca. 35GB), so I will upload the concatenation scripts in the pertpy-datasets repo. 