### PR TITLE
Fix issue #738

### DIFF
--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -1467,6 +1467,7 @@ class CompositionalModel2(ABC):
                     ax=ax,
                 )
             cell_types = pd.unique(plot_df["Cell Type"])
+            ax.set_xticks(cell_types)
             ax.set_xticklabels(cell_types, rotation=90)
 
         if return_fig and plot_facets:
@@ -1682,6 +1683,7 @@ class CompositionalModel2(ABC):
                 )
 
             cell_types = pd.unique(plot_df["Cell type"])
+            ax.set_xticks(cell_types)
             ax.set_xticklabels(cell_types, rotation=90)
 
             if show_legend:


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

- [x] Referenced issue is linked
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

**Description of changes**

I added `set_xticks` calls to silence the warning in issue https://github.com/scverse/pertpy/issues/738.

**Technical details**

I did not test this as I don't know how to (easily) build and test pertpy locally.
However, I did reproduce the warning with a toy example and this solution yielded the same plot without the warning.

**Additional context**

If you want me to do anything else, please provide some guidance.
I am a new contributor and currently quite busy with other work.
