### PR TITLE
Speedup import times

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v5
               with:
-                  python-version: "3.13"
+                  python-version: "3.x"
                   cache: "pip"
                   cache-dependency-path: "**/pyproject.toml"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
             - name: Install R
               uses: r-lib/actions/setup-r@v2
               with:
-                  r-version: "4"
+                  r-version: "4.4.3"
 
             - name: Install edgeR
               run: Rscript --vanilla -e "install.packages(c('BiocManager', 'statmod'), repos='https://cran.r-project.org'); library('BiocManager'); BiocManager::install('edgeR')"

--- a/pertpy/preprocessing/_guide_rna_mixture.py
+++ b/pertpy/preprocessing/_guide_rna_mixture.py
@@ -104,7 +104,7 @@ class MixtureModel(ABC):
 
         with plate("data", data.shape[0]):
             log_likelihoods = self.log_likelihood(data, params)
-            log_mixture_likelihood = scipy.special.logsumexp(log_likelihoods, axis=-1)
+            log_mixture_likelihood = logsumexp(log_likelihoods, axis=-1)
             sample("obs", Normal(log_mixture_likelihood, 1.0), obs=data)
 
     def assignment(self, samples: ParamsDict, data: ndarray) -> np.ndarray:

--- a/pertpy/tools/_augur.py
+++ b/pertpy/tools/_augur.py
@@ -11,7 +11,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import scanpy as sc
-import statsmodels.api as sm
 from anndata import AnnData
 from joblib import Parallel, delayed
 from lamin_utils import logger
@@ -34,6 +33,7 @@ from sklearn.metrics import (
 from sklearn.model_selection import StratifiedKFold, cross_validate
 from sklearn.preprocessing import LabelEncoder
 from skmisc.loess import loess
+from statsmodels.api import OLS
 from statsmodels.stats.multitest import fdrcorrection
 
 from pertpy._doc import _doc_params, doc_common_plot_args
@@ -589,9 +589,9 @@ class Augur:
         sigma2_x = np.sum(np.power(loess1.outputs.fitted_residuals, 2)) / nobs
         sigma2_z = np.sum(np.power(loess2.outputs.fitted_residuals, 2)) / nobs
         yhat_x = loess1.outputs.fitted_values
-        res_dx = sm.OLS(yhat_x, z).fit()
+        res_dx = OLS(yhat_x, z).fit()
         err_zx = res_dx.resid
-        res_xzx = sm.OLS(err_zx, x).fit()
+        res_xzx = OLS(err_zx, x).fit()
         err_xzx = res_xzx.resid
 
         sigma2_zx = sigma2_x + np.dot(err_zx.T, err_zx) / nobs

--- a/pertpy/tools/_cinemaot.py
+++ b/pertpy/tools/_cinemaot.py
@@ -7,12 +7,12 @@ import numpy as np
 import pandas as pd
 import scanpy as sc
 import scipy.stats as ss
-import seaborn as sns
 import sklearn.metrics
-from ott.geometry import pointcloud
+from ott.geometry.pointcloud import PointCloud
 from ott.problems.linear import linear_problem
 from ott.solvers.linear import sinkhorn, sinkhorn_lr
 from scanpy.plotting import _utils
+from seaborn import heatmap
 from scipy.sparse import issparse
 from sklearn.decomposition import FastICA
 from sklearn.linear_model import LinearRegression
@@ -111,7 +111,7 @@ class Cinemaot:
             sklearn.metrics.pairwise_distances(cf1, cf2)
 
         e = smoothness * sum(xi < thres)
-        geom = pointcloud.PointCloud(cf1, cf2, epsilon=e, batch_size=batch_size)
+        geom = PointCloud(cf1, cf2, epsilon=e, batch_size=batch_size)
 
         if preweight_label is None:
             ot_prob = linear_problem.LinearProblem(geom, a=None, b=None)
@@ -719,7 +719,7 @@ class Cinemaot:
         else:
             df = (df.T / df.sum(axis=1)).T
 
-        g = sns.heatmap(df, annot=True, ax=ax, **kwargs)
+        g = heatmap(df, annot=True, ax=ax, **kwargs)
         plt.title(title)
 
         if return_fig:

--- a/pertpy/tools/_distances/_distances.py
+++ b/pertpy/tools/_distances/_distances.py
@@ -4,9 +4,9 @@ import multiprocessing
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Literal, NamedTuple
 
-import numba
 import numpy as np
 import pandas as pd
+from numba import jit
 from ott.geometry.geometry import Geometry
 from ott.geometry.pointcloud import PointCloud
 from ott.problems.linear.linear_problem import LinearProblem
@@ -968,7 +968,7 @@ class NBLL(AbstractDistance):
         if not _is_count_matrix(matrix=X) or not _is_count_matrix(matrix=Y):
             raise ValueError("NBLL distance only works for raw counts.")
 
-        @numba.jit(forceobj=True)
+        @jit(forceobj=True)
         def _compute_nll(y: np.ndarray, nb_params: tuple[float, float], epsilon: float) -> float:
             mu = np.exp(nb_params[0])
             theta = 1 / nb_params[1]

--- a/pertpy/tools/_perturbation_space/_comparison.py
+++ b/pertpy/tools/_perturbation_space/_comparison.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 import numpy as np
-import pynndescent
+from pynndescent import NNDescent
 from scipy.sparse import issparse
 from scipy.sparse import vstack as sp_vstack
 from sklearn.base import ClassifierMixin
@@ -95,7 +95,7 @@ class PerturbationComparison:
             labels[-control.shape[0] :] = "ctrl"
             label_groups.append("ctrl")
 
-        index = pynndescent.NNDescent(
+        index = NNDescent(
             index_data,
             n_neighbors=max(50, n_neighbors),
             random_state=random_state,

--- a/pertpy/tools/_perturbation_space/_comparison.py
+++ b/pertpy/tools/_perturbation_space/_comparison.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING
 
 import numpy as np
-from pynndescent import NNDescent
 from scipy.sparse import issparse
 from scipy.sparse import vstack as sp_vstack
 from sklearn.base import ClassifierMixin
@@ -95,6 +94,7 @@ class PerturbationComparison:
             labels[-control.shape[0] :] = "ctrl"
             label_groups.append("ctrl")
 
+        from pynndescent import NNDescent
         index = NNDescent(
             index_data,
             n_neighbors=max(50, n_neighbors),

--- a/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
+++ b/pertpy/tools/_perturbation_space/_discriminator_classifiers.py
@@ -5,11 +5,11 @@ import warnings
 import anndata
 import numpy as np
 import pandas as pd
-import pytorch_lightning as pl
 import scipy
 import torch
 from anndata import AnnData
 from pytorch_lightning.callbacks import EarlyStopping
+from pytorch_lightning import Trainer, LightningModule
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import OneHotEncoder
@@ -246,7 +246,7 @@ class MLPClassifierSpace(PerturbationSpace):
         # Save adata observations for embedding annotations in get_embeddings
         self.adata_obs = adata.obs.reset_index(drop=True)
 
-        self.trainer = pl.Trainer(
+        self.trainer = Trainer(
             min_epochs=1,
             max_epochs=max_epochs,
             check_val_every_n_epoch=val_epochs_check,
@@ -412,7 +412,7 @@ class PLDataset(Dataset):
         return sample, num_label, str_label
 
 
-class PerturbationClassifier(pl.LightningModule):
+class PerturbationClassifier(LightningModule):
     def __init__(
         self,
         model: torch.nn.Module,

--- a/pertpy/tools/_perturbation_space/_simple.py
+++ b/pertpy/tools/_perturbation_space/_simple.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import decoupler as dc
 import matplotlib.pyplot as plt
 import numpy as np
 from anndata import AnnData
 from sklearn.cluster import DBSCAN, KMeans
+from decoupler import get_pseudobulk, plot_psbulk_samples
 
 from pertpy._doc import _doc_params, doc_common_plot_args
 from pertpy.tools._perturbation_space._clustering import ClusteringSpace
@@ -168,7 +168,7 @@ class PseudobulkSpace(PerturbationSpace):
                 adata = adata_emb
 
         adata.obs[target_col] = adata.obs[target_col].astype("category")
-        ps_adata = dc.get_pseudobulk(adata, sample_col=target_col, layer=layer_key, groups_col=groups_col, **kwargs)  # type: ignore
+        ps_adata = get_pseudobulk(adata, sample_col=target_col, layer=layer_key, groups_col=groups_col, **kwargs)  # type: ignore
 
         ps_adata.obs[target_col] = ps_adata.obs[target_col].astype("category")
 
@@ -208,7 +208,7 @@ class PseudobulkSpace(PerturbationSpace):
         Preview:
             .. image:: /_static/docstring_previews/pseudobulk_samples.png
         """
-        fig = dc.plot_psbulk_samples(adata, groupby, return_fig=True, **kwargs)
+        fig = plot_psbulk_samples(adata, groupby, return_fig=True, **kwargs)
 
         if return_fig:
             return fig

--- a/pertpy/tools/_perturbation_space/_simple.py
+++ b/pertpy/tools/_perturbation_space/_simple.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from anndata import AnnData
 from sklearn.cluster import DBSCAN, KMeans
-from decoupler import get_pseudobulk, plot_psbulk_samples
+from decoupler import (get_pseudobulk as dc_get_pseudobulk, plot_psbulk_samples as dc_plot_psbulk_samples)
 
 from pertpy._doc import _doc_params, doc_common_plot_args
 from pertpy.tools._perturbation_space._clustering import ClusteringSpace
@@ -168,7 +168,7 @@ class PseudobulkSpace(PerturbationSpace):
                 adata = adata_emb
 
         adata.obs[target_col] = adata.obs[target_col].astype("category")
-        ps_adata = get_pseudobulk(adata, sample_col=target_col, layer=layer_key, groups_col=groups_col, **kwargs)  # type: ignore
+        ps_adata = dc_get_pseudobulk(adata, sample_col=target_col, layer=layer_key, groups_col=groups_col, **kwargs)  # type: ignore
 
         ps_adata.obs[target_col] = ps_adata.obs[target_col].astype("category")
 
@@ -208,7 +208,7 @@ class PseudobulkSpace(PerturbationSpace):
         Preview:
             .. image:: /_static/docstring_previews/pseudobulk_samples.png
         """
-        fig = plot_psbulk_samples(adata, groupby, return_fig=True, **kwargs)
+        fig = dc_plot_psbulk_samples(adata, groupby, return_fig=True, **kwargs)
 
         if return_fig:
             return fig


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

- [x] Referenced issue is linked
- [x] No additional tests needed
- [x] No documentation in `docs` needs to be updated

**Description of changes**
Changed imports of heavy packages (jax, ott, numpyro, pytorch_lightning, scipy, numba, numpyro) to only import what's needed. Addresses issue https://github.com/scverse/pertpy/issues/742

**Technical details**

<!-- Please state any technical details such as limitations, reasons for additional dependencies, benchmarks etc. here. -->

**Additional context**
Results in more than 50% reduction of import times on our EMBL HPC. Remaining import time is mostly (65%) due to anndata / scanpy utils which is not for us to solve. See profilings attached.
<!-- Add any other context or screenshots here. -->

Profiling before speedup:
![433396572-4651606a-9f8c-4248-9467-0c18a8ea9e07](https://github.com/user-attachments/assets/de0f75a5-a765-45d2-b6b6-895dab5e0e5c)


Profiling after speedup:
![Screenshot 2025-04-14 at 16 40 36](https://github.com/user-attachments/assets/fb9a63f2-67bc-49e2-a1e5-ec2f1ef45184)
