### PR TITLE
Support > 2 colors in `pt.tl.Sccoda.plot_boxplots`

### DIFF
--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -1538,7 +1538,7 @@ class CompositionalModel2(ABC):
         if isinstance(data, MuData):
             data = data[modality_key]
         if isinstance(palette, Colormap):
-            palette = palette(range(2))
+            palette = palette(range(len(data.obs[feature_name].unique())))
 
         # y scale transformations
         if y_scale == "relative":


### PR DESCRIPTION
Fixes https://github.com/scverse/pertpy/issues/781.

<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [X] Referenced issue is linked
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Instead of using a fixed number of two columns, the code now checks for how many distinct value for the feature to be plotted are observed in the data.

**Technical details**

Test as follows:

```python
import pertpy as pt
from matplotlib import cm

haber_cells = pt.dt.haber_2017_regions()

sccoda_model = pt.tl.Sccoda()
sccoda_data = sccoda_model.load(
    haber_cells,
    type="cell_level",
    generate_sample_level=True,
    cell_type_identifier="cell_label",
    sample_identifier="batch",
    covariate_obs=["condition"],
)

sccoda_data.mod["coda_salm"] = sccoda_data["coda"][
    sccoda_data["coda"].obs["condition"].isin(["Control", "Salmonella"])
].copy()

sccoda_model.plot_boxplots(sccoda_data, modality_key="coda_salm",
                           feature_name="condition", add_dots=True)
sccoda_model.plot_boxplots(sccoda_data, modality_key="coda_salm",
                           feature_name="condition", add_dots=True,
                           palette="BuPu")
sccoda_model.plot_boxplots(sccoda_data, modality_key="coda_salm",
                           feature_name="condition", add_dots=True,
                           palette=cm.BuPu)
```

**Additional context**

The above test throws a warning:

```
<path>/pertpy/tools/_coda/_base_coda.py:1645: UserWarning: Numpy array is not a supported type for `palette`. Please convert your palette to a list. This will become an error in v0.14
```

However, that is unrelated to the PR and can be reproduced on `main` as well.
This should be tracked in a separate issue and fixed across the code base in another PR I think.
If I get to it, I will have a shot at it, but no promises. 😉 

---
*edit*: I opened https://github.com/scverse/pertpy/issues/785 to track the above warning.