### PR TITLE
Fixed GDSC and PRISM annotation warnings

### DIFF
--- a/pertpy/metadata/_cell_line.py
+++ b/pertpy/metadata/_cell_line.py
@@ -195,7 +195,9 @@ class CellLine(MetaData):
                 block_size=4096,
                 is_zip=False,
             )
-        df = pd.read_csv(drug_response_prism_file_path, index_col=0, usecols=["broad_id", "depmap_id", "name", "ic50", "ec50", "auc"])
+        df = pd.read_csv(
+            drug_response_prism_file_path, index_col=0, usecols=["broad_id", "depmap_id", "name", "ic50", "ec50", "auc"]
+        )
         df = df.dropna(subset=["depmap_id", "name"])
         df = df.groupby(["depmap_id", "name"]).mean().reset_index()
         self.drug_response_prism = df


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

-   [x] Referenced issue is linked (closes #753)
-   [x] If you've fixed a bug or added code that should be tested, add tests!

**Description of changes**

This PR fixes three warnings that were previously raised when fetching and storing cell-line-level metadata annotations from GDSC and PRISM. 

**Technical details**

**Warning 1: `AnnData expects .obs.index to contain strings, but got values like [integers]`**
If `adata.obs.index.name` is `None`, the index reset logic defaulted to using `adata.obs["index"]`. However, this column is not guaranteed to exist, because `reset_index()` stores the old index in a column named `"level_0"`.

So, why didn’t the code fail? Before calling `annotate_from_gdsc()` or `annotate_from_prism()`, we call `annotate()`, which performs a `merge()` operation. During this merge, the original index of the right-hand DataFrame (`cell_line_meta`) is stored as a new column `"index"`. These values were integers and then ended up being used as the `.obs.index` when annotating from GDSC or PRISM, which raised the warning. In short, the `.obs.index` was being reset incorrectly to a column of integers, rather than to the original string-based index.

I fixed this by simply setting `adata.obs.index.name` to `original_index` (unless it is already set), which ensures that, during index resets, we correctly recover the original `adata.obs.index`, which contains the expected string values.

**Warning 2: `DtypeWarning: Columns (14,15) have mixed types. Specify dtype option on import or set low_memory=False.`**
This warning was raised in `annotate_from_prism`, when reading the PRISM CSV file. However, columns 14 and 15 are not used for annotation anyways. So, to avoid this warning and speed up the read, I added the `usecols` parameter to `pd.read_csv()` to load only the necessary columns, all of which have consistent data types.

