### PR TITLE
ci: fix isort formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ markers = [
     "conda: marks a subset of tests to be ran on the Bioconda CI.",
     "extra: marks tests that require extra dependencies.",
 ]
-minversion = 6.0
+minversion = "6.0"
 norecursedirs = [ '.*', 'build', 'dist', '*.egg', 'data', '__pycache__']
 filterwarnings = [
     "ignore::Warning:statsmodels.*",
@@ -195,7 +195,7 @@ select = [
     "BLE",    # flake8-blind-except
     "UP",     # pyupgrade
     "RUF100", # Report unused noqa directives
-    "TCH",    # Typing imports
+    "TC",     # Typing imports
     "NPY",    # Numpy specific rules
     "PTH",    # Use pathlib
     "PERF",   # Performance
@@ -250,6 +250,9 @@ ignore = [
     # import should be at top of file
     "PLC0415"
 ]
+
+[tool.ruff.lint.isort]
+known-first-party = ["pertpy"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/tests/metadata/test_cell_line.py
+++ b/tests/metadata/test_cell_line.py
@@ -1,10 +1,11 @@
 import anndata
 import numpy as np
 import pandas as pd
-import pertpy as pt
 import pytest
 from anndata import AnnData
 from scipy import sparse
+
+import pertpy as pt
 
 NUM_CELLS = 100
 NUM_GENES = 100

--- a/tests/metadata/test_compound.py
+++ b/tests/metadata/test_compound.py
@@ -3,11 +3,12 @@ import time
 import anndata
 import numpy as np
 import pandas as pd
-import pertpy as pt
 import pytest
 from anndata import AnnData
 from pubchempy import PubChemHTTPError
 from scipy import sparse
+
+import pertpy as pt
 
 NUM_CELLS = 100
 NUM_GENES = 100

--- a/tests/metadata/test_drug.py
+++ b/tests/metadata/test_drug.py
@@ -1,9 +1,10 @@
 import anndata
 import numpy as np
 import pandas as pd
-import pertpy as pt
 import pytest
 from anndata import AnnData
+
+import pertpy as pt
 
 pt_drug = pt.md.Drug()
 

--- a/tests/metadata/test_moa.py
+++ b/tests/metadata/test_moa.py
@@ -1,10 +1,11 @@
 import anndata
 import numpy as np
 import pandas as pd
-import pertpy as pt
 import pytest
 from anndata import AnnData
 from scipy import sparse
+
+import pertpy as pt
 
 NUM_CELLS = 100
 NUM_GENES = 100

--- a/tests/preprocessing/test_grna_assignment.py
+++ b/tests/preprocessing/test_grna_assignment.py
@@ -1,9 +1,10 @@
 import anndata as ad
 import numpy as np
 import pandas as pd
-import pertpy as pt
 import pytest
 from scipy import sparse
+
+import pertpy as pt
 
 
 @pytest.fixture

--- a/tests/tools/_coda/test_sccoda.py
+++ b/tests/tools/_coda/test_sccoda.py
@@ -3,10 +3,11 @@ from pathlib import Path
 import arviz as az
 import numpy as np
 import pandas as pd
-import pertpy as pt
 import pytest
 import scanpy as sc
 from mudata import MuData
+
+import pertpy as pt
 
 CWD = Path(__file__).parent.resolve()
 

--- a/tests/tools/_differential_gene_expression/test_edger.py
+++ b/tests/tools/_differential_gene_expression/test_edger.py
@@ -1,5 +1,6 @@
 import numpy.testing as npt
 import pytest
+
 from pertpy.tools._differential_gene_expression import EdgeR
 
 try:

--- a/tests/tools/_differential_gene_expression/test_input_checks.py
+++ b/tests/tools/_differential_gene_expression/test_input_checks.py
@@ -4,6 +4,7 @@ import anndata as ad
 import numpy as np
 import pytest
 import scipy.sparse as sp
+
 from pertpy.tools._differential_gene_expression._checks import check_is_integer_matrix, check_is_numeric_matrix
 
 if find_spec("formulaic_contrasts") is None or find_spec("formulaic") is None:

--- a/tests/tools/_distances/test_distance_tests.py
+++ b/tests/tools/_distances/test_distance_tests.py
@@ -1,7 +1,8 @@
-import pertpy as pt
 import pytest
 import scanpy as sc
 from pandas import DataFrame
+
+import pertpy as pt
 
 distances = [
     "edistance",

--- a/tests/tools/_distances/test_distances.py
+++ b/tests/tools/_distances/test_distances.py
@@ -1,9 +1,10 @@
 import numpy as np
-import pertpy as pt
 import pytest
 import scanpy as sc
 from pandas import DataFrame, Series
 from pytest import fixture, mark
+
+import pertpy as pt
 
 actual_distances = [
     # Euclidean distances and related

--- a/tests/tools/_perturbation_space/test_comparison.py
+++ b/tests/tools/_perturbation_space/test_comparison.py
@@ -1,5 +1,6 @@
-import pertpy as pt
 import pytest
+
+import pertpy as pt
 
 
 @pytest.fixture

--- a/tests/tools/_perturbation_space/test_discriminator_classifiers.py
+++ b/tests/tools/_perturbation_space/test_discriminator_classifiers.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pandas as pd
-import pertpy as pt
 import pytest
 from anndata import AnnData
+
+import pertpy as pt
 
 
 @pytest.fixture

--- a/tests/tools/_perturbation_space/test_simple_cluster_space.py
+++ b/tests/tools/_perturbation_space/test_simple_cluster_space.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pandas as pd
-import pertpy as pt
 from anndata import AnnData
+
+import pertpy as pt
 
 
 def test_clustering():

--- a/tests/tools/_perturbation_space/test_simple_perturbation_space.py
+++ b/tests/tools/_perturbation_space/test_simple_perturbation_space.py
@@ -1,9 +1,10 @@
 import numpy as np
 import pandas as pd
-import pertpy as pt
 import pytest
 import scanpy as sc
 from anndata import AnnData
+
+import pertpy as pt
 
 
 @pytest.fixture

--- a/tests/tools/test_augur.py
+++ b/tests/tools/test_augur.py
@@ -2,9 +2,10 @@ from math import isclose
 from pathlib import Path
 
 import numpy as np
-import pertpy as pt
 import pytest
 import scanpy as sc
+
+import pertpy as pt
 
 CWD = Path(__file__).parent.resolve()
 

--- a/tests/tools/test_cinemaot.py
+++ b/tests/tools/test_cinemaot.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 
 import numpy as np
-import pertpy as pt
 import scanpy as sc
 from _pytest.fixtures import fixture
+
+import pertpy as pt
 
 CWD = Path(__file__).parent.resolve()
 

--- a/tests/tools/test_core.py
+++ b/tests/tools/test_core.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
-from pertpy.tools.core import _is_raw_counts
 from scipy import sparse
+
+from pertpy.tools.core import _is_raw_counts
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_dialogue.py
+++ b/tests/tools/test_dialogue.py
@@ -1,6 +1,7 @@
 import pandas as pd
-import pertpy as pt
 import scanpy as sc
+
+import pertpy as pt
 
 # This is not a proper test!
 # We are only testing a few functions to ensure that at least these run

--- a/tests/tools/test_enrichment.py
+++ b/tests/tools/test_enrichment.py
@@ -1,8 +1,9 @@
 import numpy as np
-import pertpy as pt
 import pytest
 import scanpy as sc
 from anndata import AnnData
+
+import pertpy as pt
 
 
 @pytest.fixture

--- a/tests/tools/test_milo.py
+++ b/tests/tools/test_milo.py
@@ -2,10 +2,11 @@ from importlib.util import find_spec
 
 import numpy as np
 import pandas as pd
-import pertpy as pt
 import pytest
 import scanpy as sc
 from mudata import MuData
+
+import pertpy as pt
 
 
 @pytest.fixture(params=["edger", "pydeseq2"])

--- a/tests/tools/test_mixscape.py
+++ b/tests/tools/test_mixscape.py
@@ -3,10 +3,11 @@ from pathlib import Path
 import anndata
 import numpy as np
 import pandas as pd
-import pertpy as pt
 import pytest
-from pertpy.tools._mixscape import MixscapeGaussianMixture
 from scipy import sparse
+
+import pertpy as pt
+from pertpy.tools._mixscape import MixscapeGaussianMixture
 
 # Random generate data settings
 NUM_CELLS_PER_GROUP = 10

--- a/tests/tools/test_scgen.py
+++ b/tests/tools/test_scgen.py
@@ -8,8 +8,9 @@ except Exception:  # noqa: BLE001
 import warnings
 
 import anndata as ad
-import pertpy as pt
 import scanpy as sc
+
+import pertpy as pt
 
 
 def test_scgen():


### PR DESCRIPTION
Running Ruff on the entire codebase has isort partially recognize `pertpy` as first-party.

This changes the config so things are consistent.