### PR TITLE
Fix PyDESeq2 layer handling in fit()

### DIFF
--- a/tests/tools/_differential_gene_expression/test_pydeseq2.py
+++ b/tests/tools/_differential_gene_expression/test_pydeseq2.py
@@ -77,3 +77,26 @@ def test_pydeseq2_formula(test_adata):
     res_2 = model2.test_contrasts(model2.contrast("condition", "A", "B"))
 
     npt.assert_almost_equal(res_2.log_fc.values, res_1.log_fc.values)
+
+
+def test_pydeseq2_uses_layer_counts_for_fit(test_adata):
+    """Regression test: when `layer` is provided, `.fit()` must use that layer as counts, not `.X`."""
+    import numpy as np
+
+    from pertpy.tools._differential_gene_expression import PyDESeq2
+
+    adata = test_adata.copy()
+    adata.layers["sum"] = adata.X.copy()
+
+    # Make X explicitly non-integer to reproduce the failure mode if `.fit()` ignores `layer=`.
+    X_layer_before = np.array(adata.layers["sum"], copy=True)
+    adata.X = np.array(adata.X, dtype=float) / 2.0
+    X_before_fit = np.array(adata.X, copy=True)
+
+    model = PyDESeq2(adata=adata, layer="sum", design="~condition")
+    model.fit(n_cpus=1)
+    res_df = model.test_contrasts(model.contrast("condition", "A", "B"))
+
+    assert len(res_df) == adata.n_vars
+    npt.assert_array_equal(X_layer_before, adata.layers["sum"])
+    npt.assert_array_equal(X_before_fit, np.array(adata.X))

--- a/tests/tools/_differential_gene_expression/test_pydeseq2.py
+++ b/tests/tools/_differential_gene_expression/test_pydeseq2.py
@@ -1,5 +1,6 @@
 from importlib.util import find_spec
 
+import numpy as np
 import numpy.testing as npt
 import pytest
 
@@ -81,22 +82,19 @@ def test_pydeseq2_formula(test_adata):
 
 def test_pydeseq2_uses_layer_counts_for_fit(test_adata):
     """Regression test: when `layer` is provided, `.fit()` must use that layer as counts, not `.X`."""
-    import numpy as np
-
     from pertpy.tools._differential_gene_expression import PyDESeq2
 
-    adata = test_adata.copy()
-    adata.layers["sum"] = adata.X.copy()
+    test_adata.layers["sum"] = test_adata.X.copy()
 
     # Make X explicitly non-integer to reproduce the failure mode if `.fit()` ignores `layer=`.
-    X_layer_before = np.array(adata.layers["sum"], copy=True)
-    adata.X = np.array(adata.X, dtype=float) / 2.0
-    X_before_fit = np.array(adata.X, copy=True)
+    X_layer_before = np.array(test_adata.layers["sum"], copy=True)
+    test_adata.X = np.array(test_adata.X, dtype=float) / 2.0
+    X_before_fit = np.array(test_adata.X, copy=True)
 
-    model = PyDESeq2(adata=adata, layer="sum", design="~condition")
+    model = PyDESeq2(adata=test_adata, layer="sum", design="~condition")
     model.fit(n_cpus=1)
     res_df = model.test_contrasts(model.contrast("condition", "A", "B"))
 
-    assert len(res_df) == adata.n_vars
-    npt.assert_array_equal(X_layer_before, adata.layers["sum"])
-    npt.assert_array_equal(X_before_fit, np.array(adata.X))
+    assert len(res_df) == test_adata.n_vars
+    npt.assert_array_equal(X_layer_before, test_adata.layers["sum"])
+    npt.assert_array_equal(X_before_fit, np.array(test_adata.X))


### PR DESCRIPTION
### Problem
`PyDESeq2(..., layer=...)` validates the layer at init, but `.fit()` passed the original AnnData to PyDESeq2, which always reads `adata.X`. If `X` is non-integer (e.g. normalized), `.fit()` fails with `ValueError: The count matrix should only contain integers.`

### Fix
When `layer` is set, build an internal counts-only AnnData with `.X = adata.layers[layer]` (no mutation of user `.X`) and pass that to `DeseqDataSet`.

### Test
Add regression test where `.X` is non-integer but `layer` contains integer counts; assert `.fit()` succeeds and `.X` is unchanged.
