### PR TITLE
Fix plot_effects_umap KeyError on Sccoda output (#780)

### DIFF
--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -2208,7 +2208,9 @@ class CompositionalModel2(ABC):
                 cluster: palette(i % palette.N) for i, cluster in enumerate(data_rna.obs[cluster_key].unique().tolist())
             }
         for _, effect in enumerate(effect_name):
-            data_rna.obs[effect] = [data_coda.varm[effect].loc[f"{c}", "Effect"] for c in data_rna.obs[cluster_key]]
+            effect_df = data_coda.varm[effect]
+            effect_col = "Effect" if "Effect" in effect_df.columns else "Final Parameter"
+            data_rna.obs[effect] = [effect_df.loc[f"{c}", effect_col] for c in data_rna.obs[cluster_key]]
         if kwargs.get("vmin"):
             vmin = kwargs["vmin"]
             kwargs.pop("vmin")

--- a/tests/tools/_coda/test_sccoda.py
+++ b/tests/tools/_coda/test_sccoda.py
@@ -105,3 +105,30 @@ def test_make_arviz(adata):
     sccoda.run_nuts(mdata)
     arviz_data = sccoda.make_arviz(mdata, num_prior_samples=100)
     assert isinstance(arviz_data, DataTree)
+
+
+def test_plot_effects_umap_sccoda(adata):
+    # Regression test for #780: Sccoda writes effect column as "Final Parameter",
+    # not "Effect" like Tasccoda, so plot_effects_umap must look up either name.
+    adata_salm = adata[adata.obs["condition"].isin(["Control", "Salmonella"])]
+    mdata = sccoda.load(
+        adata_salm,
+        type="cell_level",
+        generate_sample_level=True,
+        cell_type_identifier="cell_label",
+        sample_identifier="batch",
+        covariate_obs=["condition"],
+    )
+    mdata = sccoda.prepare(mdata, formula="condition", reference_cell_type="Goblet")
+    sccoda.run_nuts(mdata, num_samples=200, num_warmup=50)
+    sc.pp.pca(mdata["rna"])
+    sc.pp.neighbors(mdata["rna"])
+    sc.tl.umap(mdata["rna"])
+    effect = "effect_df_condition[T.Salmonella]"
+    sccoda.plot_effects_umap(
+        mdata,
+        modality_key_2="coda",
+        effect_name=effect,
+        cluster_key="cell_label",
+    )
+    assert effect in mdata["rna"].obs.columns


### PR DESCRIPTION
Should resolve #780.

`summary_prepare` in `_base_coda.py` renames the first effect column differently per `select_type`:
- `"sslasso"` branch (Tasccoda) → `"Effect"` (line 602)
- else branch (Sccoda) → `"Final Parameter"` (line 616)

`plot_effects_umap` hardcoded `"Effect"` at line 2211, so calling it on Sccoda output crashed with `KeyError: 'Effect'`. The rest of the file already handles this divergence — for example, lines 904-917 branch on `select_type` to pick the correct column name.

This wraps the lookup so it picks `"Effect"` if present, otherwise `"Final Parameter"`. Behavior on Tasccoda is unchanged.

Also adds a regression test `test_plot_effects_umap_sccoda` that fits a small Sccoda model and confirms `plot_effects_umap` no longer crashes. Locally verified — full `tests/tools/_coda/` suite passes (6 pass, 1 pre-existing skip).