### PR TITLE
Fix PseudobulkSpace.compute losing X with anndata main

### DIFF
--- a/pertpy/tools/_perturbation_space/_simple.py
+++ b/pertpy/tools/_perturbation_space/_simple.py
@@ -168,11 +168,11 @@ class PseudobulkSpace(PerturbationSpace):
             adata, by=[target_col] if groups_col is None else [target_col, groups_col], func=mode, layer=layer_key
         )
 
-        if mode in ps_adata.layers:
-            ps_adata.X = ps_adata.layers[mode]
-
         if None in ps_adata.layers:
             del ps_adata.layers[None]
+
+        if mode in ps_adata.layers:
+            ps_adata.X = ps_adata.layers[mode]
 
         missing_cols = [col for col in original_obs.columns if col not in ps_adata.obs.columns]
         new_cols_data = {}


### PR DESCRIPTION
In anndata main, `layers` exposes a virtual `None` key aliased to `.X`. The previous order set `X = layers[mode]` then `del layers[None]`, which deleted X via the alias. `psadata.obsm["X_umap"] = psadata_umap.X` then stored `None`, breaking the later `adata.copy()` in `compute_control_diff`.