### PR TITLE
Resolve scgen test warnings

### DIFF
--- a/pertpy/tools/_scgen/_scgen.py
+++ b/pertpy/tools/_scgen/_scgen.py
@@ -243,10 +243,11 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
                 batch_list[i] = temp
                 batch_ind[i] = temp_ind
             max_batch_ann = batch_list[max_batch_ind]
+            max_batch_mean = np.average(max_batch_ann.X, axis=0)
             for study in batch_list:
-                delta = np.average(max_batch_ann.X, axis=0) - np.average(batch_list[study].X, axis=0)
+                batch_list[study] = batch_list[study].copy()
+                delta = max_batch_mean - np.average(batch_list[study].X, axis=0)
                 batch_list[study].X = delta + batch_list[study].X
-                temp_cell[batch_ind[study]].X = batch_list[study].X
             shared_ct.append(temp_cell)
 
         all_shared_ann = ad.concat(shared_ct, label="concat_batch", index_unique=None)
@@ -258,7 +259,7 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
                 obs=all_shared_ann.obs,
             )
             corrected.var_names = adata.var_names.tolist()
-            corrected = corrected[adata.obs_names]
+            corrected = corrected[adata.obs_names].copy()
             if adata.raw is not None:
                 adata_raw = AnnData(X=adata.raw.X, var=adata.raw.var)
                 adata_raw.obs_names = adata.obs_names
@@ -281,7 +282,7 @@ class Scgen(JaxTrainingMixin, BaseModelClass):
                 obs=all_corrected_data.obs,
             )
             corrected.var_names = adata.var_names.tolist()
-            corrected = corrected[adata.obs_names]
+            corrected = corrected[adata.obs_names].copy()
             if adata.raw is not None:
                 adata_raw = AnnData(X=adata.raw.X, var=adata.raw.var)
                 adata_raw.obs_names = adata.obs_names

--- a/pertpy/tools/_scgen/_utils.py
+++ b/pertpy/tools/_scgen/_utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import warnings
-
+import anndata as ad
 import numpy as np
 
 
@@ -83,9 +82,6 @@ def balancer(
         index_all.append(index_cls_r)
 
     indices = np.concatenate(index_all)
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message="Observation names are not unique")
-        balanced_data = adata[indices].copy()
-    balanced_data.obs_names_make_unique()
+    balanced_data = ad.concat([adata[i : i + 1] for i in indices], index_unique="-")
 
     return balanced_data

--- a/pertpy/tools/_scgen/_utils.py
+++ b/pertpy/tools/_scgen/_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 
 
@@ -80,6 +82,10 @@ def balancer(
         index_cls_r = index_cls[rng.choice(len(index_cls), max_number)]
         index_all.append(index_cls_r)
 
-    balanced_data = adata[np.concatenate(index_all)].copy()
+    indices = np.concatenate(index_all)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Observation names are not unique")
+        balanced_data = adata[indices].copy()
+    balanced_data.obs_names_make_unique()
 
     return balanced_data

--- a/tests/tools/test_scgen.py
+++ b/tests/tools/test_scgen.py
@@ -38,7 +38,7 @@ def test_scgen():
     # reg mean and reg var
     ctrl_adata = adata[((adata.obs["labels"] == "label_0") & (adata.obs["batch"] == "batch_0"))]
     stim_adata = adata[((adata.obs["labels"] == "label_0") & (adata.obs["batch"] == "batch_1"))]
-    eval_adata = ad.concat([ctrl_adata, stim_adata, pred], label="concat_batches")
+    eval_adata = ad.concat([ctrl_adata, stim_adata, pred], label="concat_batches", index_unique="-")
     label_0 = adata[adata.obs["labels"] == "label_0"]
     sc.tl.rank_genes_groups(label_0, groupby="batch", method="wilcoxon")
     diff_genes = label_0.uns["rank_genes_groups"]["names"]["batch_1"]


### PR DESCRIPTION
Three warning categories from `test_scgen`:

- `_scgen.py:248-249`: writing to `.X` on a view of a view. Now `.copy()` the per-batch view first, then mutate. Matches the original (no-op for `temp_cell`) semantics — the second write-back was already discarded into a transient view, mirroring upstream scGen.
- `_scgen.py:266` / `:289`: `corrected[adata.obs_names]` returns a view; the subsequent `obsm["latent"] = ...` actualises it. Added `.copy()` after the slice.
- 10× `UserWarning: Observation names are not unique`: `balancer` oversamples with replacement, producing duplicate obs_names that cascade into every downstream `_check_if_view`/`copy`. Made them unique inside `balancer`, suppressed the unavoidable warning during the intermediate slice, and passed `index_unique="-"` to the eval concat in the test.