### PR TITLE
scCODA: unify covariate index format across get_effect_df / summary / credible_effects

### DIFF
--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -861,10 +861,6 @@ class CompositionalModel2(ABC):
             effect_df.index = pd.MultiIndex.from_product(
                 (covariates, sample_adata.var.index.tolist()), names=["Covariate", "Cell Type"]
             )
-            effect_df.index = effect_df.index.set_levels(
-                effect_df.index.levels[0].str.replace("Condition", "").str.replace("[", "").str.replace("]", ""),
-                level=0,
-            )
             if model_type == "tree_agg":
                 node_df = sample_adata.uns["scCODA_params"]["node_df"]
 
@@ -1022,10 +1018,6 @@ class CompositionalModel2(ABC):
         effect_df = pd.concat(effect_dfs)
         effect_df.index = pd.MultiIndex.from_product(
             (covariates, sample_adata.var.index.tolist()), names=["Covariate", "Cell Type"]
-        )
-        effect_df.index = effect_df.index.set_levels(
-            effect_df.index.levels[0].str.replace("Condition", "").str.replace("[", "").str.replace("]", ""),
-            level=0,
         )
 
         return effect_df


### PR DESCRIPTION
Closes #766

- \`get_effect_df\` and \`summary\` previously stripped \`[\`, \`]\`, and \`\"Condition\"\` from the \`Covariate\` index after building it from patsy column names, while \`credible_effects\` left the patsy-native format alone. The two views of the same model therefore disagreed (e.g. \`conditionT.Hpoly.Day3\` vs \`condition[T.Hpoly.Day3]\`), making it awkward to join their results.
- Drop the post-hoc rewrite so all three methods agree with each other and with the \`effect_df_{cov}\` keys already stored in \`varm\`.