### PR TITLE
scCODA/tascCODA: make make_arviz stateless

### DIFF
--- a/pertpy/tools/_coda/_base_coda.py
+++ b/pertpy/tools/_coda/_base_coda.py
@@ -96,6 +96,68 @@ class CompositionalModel2(ABC):
     def set_init_mcmc_states(self, *args, **kwargs):
         pass
 
+    def _build_arviz_from_adata(
+        self,
+        sample_adata: AnnData,
+        dims: dict,
+        coords: dict,
+        rng_key: int | None,
+        num_prior_samples: int,
+        use_posterior_predictive: bool,
+    ):
+        """Build an ArviZ DataTree from MCMC samples stored on ``sample_adata``.
+
+        The samples and chain count come from ``sample_adata.uns["scCODA_params"]["mcmc"]``
+        rather than from ``self.mcmc``, so ``make_arviz`` works on stored MuData objects
+        even after the model instance has been reused for other datasets (issue #812).
+        """
+        import arviz as az
+        from numpyro.infer import Predictive
+
+        mcmc_state = sample_adata.uns.get("scCODA_params", {}).get("mcmc", {})
+        if "samples" not in mcmc_state:
+            raise ValueError("No MCMC sampling found. Please run a sampler first!")
+
+        samples = {k: np.asarray(v) for k, v in mcmc_state["samples"].items()}
+        num_chains = int(mcmc_state.get("num_chains", 1)) or 1
+
+        predict_kwargs = {
+            "counts": None,
+            "covariates": jnp.array(sample_adata.obsm["covariate_matrix"], dtype="float64"),
+            "n_total": jnp.array(sample_adata.obsm["sample_counts"], dtype="float64"),
+            "ref_index": jnp.array(sample_adata.uns["scCODA_params"]["reference_index"]),
+            "sample_adata": sample_adata,
+        }
+        rng = random.key(rng_key if rng_key is not None else int(np.random.default_rng().integers(0, 10000)))
+
+        def _grouped(d: dict, chains: int, *, predictive: bool = False) -> dict:
+            out = {}
+            for k, v in d.items():
+                arr = np.asarray(v)
+                # Drop variables whose rank past the sample axis doesn't match `dims[k]`,
+                # e.g. `counts` from `Predictive` carries an extra batch axis under
+                # numpyro's DirichletMultinomial broadcasting and would otherwise
+                # collide with the cell_type coord.
+                if predictive and len(arr.shape) - 1 != len(dims.get(k, [])):
+                    continue
+                out[k] = arr.reshape((chains, -1, *arr.shape[1:]))
+            return out
+
+        groups = {"posterior": _grouped(samples, num_chains)}
+        extra_fields = mcmc_state.get("extra_fields") or {}
+        if extra_fields:
+            groups["sample_stats"] = _grouped(extra_fields, num_chains)
+        if num_prior_samples > 0:
+            groups["prior"] = _grouped(
+                Predictive(self.model, num_samples=num_prior_samples)(rng, **predict_kwargs), 1, predictive=True
+            )
+        if use_posterior_predictive:
+            groups["posterior_predictive"] = _grouped(
+                Predictive(self.model, samples)(rng, **predict_kwargs), num_chains, predictive=True
+            )
+
+        return az.from_dict(groups, coords=coords, dims=dims)
+
     def prepare(
         self,
         sample_adata: AnnData,
@@ -265,6 +327,13 @@ class CompositionalModel2(ABC):
         for k, v in samples.items():
             samples[k] = np.array(v)
         sample_adata.uns["scCODA_params"]["mcmc"]["samples"] = samples
+
+        # Persist what `make_arviz` needs so it can rebuild ArviZ without `self.mcmc`
+        # (issue #812: the model instance gets reused across datasets in loops).
+        sample_adata.uns["scCODA_params"]["mcmc"]["num_chains"] = int(self.mcmc.num_chains)
+        sample_adata.uns["scCODA_params"]["mcmc"]["extra_fields"] = {
+            k.replace(".", "_"): np.asarray(v) for k, v in self.mcmc.get_extra_fields().items()
+        }
 
         # Evaluate results and create result dataframes (based on tree-aggregation or not)
         if sample_adata.uns["scCODA_params"]["model_type"] == "classic":

--- a/pertpy/tools/_coda/_sccoda.py
+++ b/pertpy/tools/_coda/_sccoda.py
@@ -7,9 +7,8 @@ import numpy as np
 import numpyro as npy
 import numpyro.distributions as npd
 from anndata import AnnData
-from jax import config, random
+from jax import config
 from mudata import MuData
-from numpyro.infer import Predictive
 
 from pertpy._logger import logger
 from pertpy.tools._coda._base_coda import CompositionalModel2, from_scanpy
@@ -322,8 +321,6 @@ class Sccoda(CompositionalModel2):
                 raise
         if isinstance(data, AnnData):
             sample_adata = data
-        if not self.mcmc:
-            raise ValueError("No MCMC sampling found. Please run a sampler first!")
 
         # feature names
         cell_types = sample_adata.var.index.to_list()
@@ -352,69 +349,14 @@ class Sccoda(CompositionalModel2):
             "obs": sample_adata.obs.index,
         }
 
-        dtype = "float64"
-
-        # Prior and posterior predictive simulation
-        numpyro_covariates = jnp.array(sample_adata.obsm["covariate_matrix"], dtype=dtype)
-        numpyro_n_total = jnp.array(sample_adata.obsm["sample_counts"], dtype=dtype)
-        ref_index = jnp.array(sample_adata.uns["scCODA_params"]["reference_index"])
-
-        if rng_key is None:
-            rng = np.random.default_rng()
-            rng_key = random.key(rng.integers(0, 10000))
-        else:
-            rng_key = random.key(rng_key)
-
-        if use_posterior_predictive:
-            posterior_predictive = Predictive(self.model, self.mcmc.get_samples())(
-                rng_key,
-                counts=None,
-                covariates=numpyro_covariates,
-                n_total=numpyro_n_total,
-                ref_index=ref_index,
-                sample_adata=sample_adata,
-            )
-            # Remove problematic posterior predictive arrays with wrong dimensions
-            if posterior_predictive and "counts" in posterior_predictive:
-                counts_shape = posterior_predictive["counts"].shape
-                expected_dims = 2  # ['sample', 'cell_type']
-                if len(counts_shape) != expected_dims:
-                    posterior_predictive = {k: v for k, v in posterior_predictive.items() if k != "counts"}
-                    logger.warning(
-                        f"Removed 'counts' from posterior_predictive due to dimension mismatch: got {len(counts_shape)}D, expected {expected_dims}D"
-                    )
-        else:
-            posterior_predictive = None
-
-        if num_prior_samples > 0:
-            prior = Predictive(self.model, num_samples=num_prior_samples)(
-                rng_key,
-                counts=None,
-                covariates=numpyro_covariates,
-                n_total=numpyro_n_total,
-                ref_index=ref_index,
-                sample_adata=sample_adata,
-            )
-            # Remove problematic prior arrays with wrong dimensions
-            if prior and "counts" in prior:
-                counts_shape = prior["counts"].shape
-                expected_dims = 2  # ['sample', 'cell_type']
-                if len(counts_shape) != expected_dims:
-                    prior = {k: v for k, v in prior.items() if k != "counts"}
-                    logger.warning(
-                        f"Removed 'counts' from prior due to dimension mismatch: got {len(counts_shape)}D, expected {expected_dims}D"
-                    )
-        else:
-            prior = None
-
-        import arviz as az
-
-        # Create arviz object
-        arviz_data = az.from_numpyro(
-            self.mcmc, prior=prior, posterior_predictive=posterior_predictive, dims=dims, coords=coords
+        return self._build_arviz_from_adata(
+            sample_adata,
+            dims=dims,
+            coords=coords,
+            rng_key=rng_key,
+            num_prior_samples=num_prior_samples,
+            use_posterior_predictive=use_posterior_predictive,
         )
-
-        return arviz_data
 
     def run_nuts(
         self,

--- a/pertpy/tools/_coda/_tasccoda.py
+++ b/pertpy/tools/_coda/_tasccoda.py
@@ -8,9 +8,8 @@ import numpyro as npy
 import numpyro.distributions as npd
 import toytree as tt
 from anndata import AnnData
-from jax import config, random
+from jax import config
 from mudata import MuData
-from numpyro.infer import Predictive
 
 from pertpy._logger import logger
 from pertpy.tools._coda._base_coda import (
@@ -495,8 +494,6 @@ class Tasccoda(CompositionalModel2):
                 raise
         if isinstance(data, AnnData):
             sample_adata = data
-        if not self.mcmc:
-            raise ValueError("No MCMC sampling found. Please run a sampler first!")
 
         # feature names
         cell_types = sample_adata.var.index.to_list()
@@ -529,69 +526,14 @@ class Tasccoda(CompositionalModel2):
             "obs": sample_adata.obs.index,
         }
 
-        dtype = "float64"
-
-        # Prior and posterior predictive simulation
-        numpyro_covariates = jnp.array(sample_adata.obsm["covariate_matrix"], dtype=dtype)
-        numpyro_n_total = jnp.array(sample_adata.obsm["sample_counts"], dtype=dtype)
-        ref_index = jnp.array(sample_adata.uns["scCODA_params"]["reference_index"])
-
-        if rng_key is None:
-            rng = np.random.default_rng()
-            rng_key = random.key(rng.integers(0, 10000))
-        else:
-            rng_key = random.key(rng_key)
-
-        if use_posterior_predictive:
-            posterior_predictive = Predictive(self.model, self.mcmc.get_samples())(
-                rng_key,
-                counts=None,
-                covariates=numpyro_covariates,
-                n_total=numpyro_n_total,
-                ref_index=ref_index,
-                sample_adata=sample_adata,
-            )
-            # Remove problematic posterior predictive arrays with wrong dimensions
-            if posterior_predictive and "counts" in posterior_predictive:
-                counts_shape = posterior_predictive["counts"].shape
-                expected_dims = 2  # ['sample', 'cell_type']
-                if len(counts_shape) != expected_dims:
-                    posterior_predictive = {k: v for k, v in posterior_predictive.items() if k != "counts"}
-                    logger.warning(
-                        f"Removed 'counts' from posterior_predictive due to dimension mismatch: got {len(counts_shape)}D, expected {expected_dims}D"
-                    )
-        else:
-            posterior_predictive = None
-
-        if num_prior_samples > 0:
-            prior = Predictive(self.model, num_samples=num_prior_samples)(
-                rng_key,
-                counts=None,
-                covariates=numpyro_covariates,
-                n_total=numpyro_n_total,
-                ref_index=ref_index,
-                sample_adata=sample_adata,
-            )
-            # Remove problematic prior arrays with wrong dimensions
-            if prior and "counts" in prior:
-                counts_shape = prior["counts"].shape
-                expected_dims = 2  # ['sample', 'cell_type']
-                if len(counts_shape) != expected_dims:
-                    prior = {k: v for k, v in prior.items() if k != "counts"}
-                    logger.warning(
-                        f"Removed 'counts' from prior due to dimension mismatch: got {len(counts_shape)}D, expected {expected_dims}D"
-                    )
-        else:
-            prior = None
-
-        import arviz as az
-
-        # Create arviz object
-        arviz_data = az.from_numpyro(
-            self.mcmc, prior=prior, posterior_predictive=posterior_predictive, dims=dims, coords=coords
+        return self._build_arviz_from_adata(
+            sample_adata,
+            dims=dims,
+            coords=coords,
+            rng_key=rng_key,
+            num_prior_samples=num_prior_samples,
+            use_posterior_predictive=use_posterior_predictive,
         )
-
-        return arviz_data
 
     def run_nuts(
         self,


### PR DESCRIPTION
Closes #812

- `make_arviz` previously relied on `self.mcmc`, the MCMC object from the last `run_nuts`/`run_hmc` call on the model instance. Looping over datasets and reusing the same model then made `make_arviz(processed_models["region_A"])` blow up with a shape mismatch because `self.mcmc` reflected the last iteration.
- Persist `num_chains` and `extra_fields` alongside the existing posterior samples in `sample_adata.uns["scCODA_params"]["mcmc"]` so an ArviZ DataTree can be rebuilt from the MuData alone via `az.from_dict`. Both `Sccoda.make_arviz` and `Tasccoda.make_arviz` now delegate to a shared helper in `CompositionalModel2`.