### PR TITLE
milo: speed up pydeseq2 da_nhoods ~100x via poscounts size factors

### DIFF
--- a/pertpy/tools/_milo.py
+++ b/pertpy/tools/_milo.py
@@ -455,6 +455,7 @@ class Milo:
                 metadata=design_df_filtered,
                 design=design_clean,
                 refit_cooks=True,
+                size_factors_fit_type="poscounts",
             )
 
             dds.deseq2()


### PR DESCRIPTION
## Summary
- Closes #816.
- `da_nhoods` runs PyDESeq2 on the neighbourhood-by-sample count matrix. That matrix is sparse — most samples have zero cells in most neighbourhoods — so PyDESeq2's default \`size_factors_fit_type=\"ratio\"\` cannot compute log geometric means (\"Switching to iterative mode.\") and falls back to a slow iterative size-factor fit. On the Milo tutorial that costs ~5 min per call, with 3 pydeseq2 calls in the notebook.
- Pass \`size_factors_fit_type=\"poscounts\"\` explicitly. It uses geometric means over positive counts only, is the variant DESeq2 itself recommends for sparse / zero-inflated data, and skips the iterative fallback.

## Effect (Stephenson tutorial)
| | baseline | this PR |
|---|---|---|
| pydeseq2 \`da_nhoods\` #1 (\`~Site+Status\`) | 322.0s | 3.0s |
| pydeseq2 \`da_nhoods\` #2 (\`~Site+COVID_severity\`) | 319.2s | 1.7s |
| pydeseq2 \`da_nhoods\` #3 (\`~Site+COVID_severity_continuous\`) | 303.5s | 1.6s |
| **total notebook runtime** | **17.0 min** | **1.3 min** |
