### PR TITLE
docs: refresh DE docstring pseudobulk examples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,6 +111,7 @@ add_module_names = False
 autodoc_mock_imports = ["ete4"]
 intersphinx_mapping = {
     "anndata": ("https://anndata.readthedocs.io/en/stable/", None),
+    "decoupler": ("https://decoupler.readthedocs.io/en/latest/", None),
     "mudata": ("https://mudata.readthedocs.io/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),

--- a/pertpy/tools/_differential_gene_expression/_base.py
+++ b/pertpy/tools/_differential_gene_expression/_base.py
@@ -83,15 +83,7 @@ class MethodBase(ABC):
             >>> adata = pt.dt.zhang_2021()
             >>> adata.layers["counts"] = adata.X.copy()
             >>> ps = pt.tl.PseudobulkSpace()
-            >>> pdata = ps.compute(
-            ...     adata,
-            ...     target_col="Patient",
-            ...     groups_col="Cluster",
-            ...     layer_key="counts",
-            ...     mode="sum",
-            ...     min_cells=10,
-            ...     min_counts=1000,
-            ... )
+            >>> pdata = ps.compute(adata, target_col="Patient", groups_col="Cluster", layer_key="counts", mode="sum")
             >>> edgr = pt.tl.EdgeR(pdata, design="~Efficacy+Treatment")
             >>> res_df = edgr.compare_groups(pdata, column="Efficacy", baseline="SD", groups_to_compare=["PR", "PD"])
         """
@@ -163,15 +155,7 @@ class MethodBase(ABC):
             >>> adata = pt.dt.zhang_2021()
             >>> adata.layers["counts"] = adata.X.copy()
             >>> ps = pt.tl.PseudobulkSpace()
-            >>> pdata = ps.compute(
-            ...     adata,
-            ...     target_col="Patient",
-            ...     groups_col="Cluster",
-            ...     layer_key="counts",
-            ...     mode="sum",
-            ...     min_cells=10,
-            ...     min_counts=1000,
-            ... )
+            >>> pdata = ps.compute(adata, target_col="Patient", groups_col="Cluster", layer_key="counts", mode="sum")
             >>> edgr = pt.tl.EdgeR(pdata, design="~Efficacy+Treatment")
             >>> edgr.fit()
             >>> res_df = edgr.test_contrasts(
@@ -538,15 +522,7 @@ class MethodBase(ABC):
             >>> adata = pt.dt.zhang_2021()
             >>> adata.layers["counts"] = adata.X.copy()
             >>> ps = pt.tl.PseudobulkSpace()
-            >>> pdata = ps.compute(
-            ...     adata,
-            ...     target_col="Patient",
-            ...     groups_col="Cluster",
-            ...     layer_key="counts",
-            ...     mode="sum",
-            ...     min_cells=10,
-            ...     min_counts=1000,
-            ... )
+            >>> pdata = ps.compute(adata, target_col="Patient", groups_col="Cluster", layer_key="counts", mode="sum")
             >>> edgr = pt.tl.EdgeR(pdata, design="~Efficacy+Treatment")
             >>> edgr.fit()
             >>> res_df = edgr.test_contrasts(
@@ -704,15 +680,7 @@ class MethodBase(ABC):
             >>> adata = pt.dt.zhang_2021()
             >>> adata.layers["counts"] = adata.X.copy()
             >>> ps = pt.tl.PseudobulkSpace()
-            >>> pdata = ps.compute(
-            ...     adata,
-            ...     target_col="Patient",
-            ...     groups_col="Cluster",
-            ...     layer_key="counts",
-            ...     mode="sum",
-            ...     min_cells=10,
-            ...     min_counts=1000,
-            ... )
+            >>> pdata = ps.compute(adata, target_col="Patient", groups_col="Cluster", layer_key="counts", mode="sum")
             >>> edgr = pt.tl.EdgeR(pdata, design="~Efficacy+Treatment")
             >>> edgr.fit()
             >>> res_df = edgr.test_contrasts(
@@ -791,15 +759,7 @@ class MethodBase(ABC):
             >>> adata = pt.dt.zhang_2021()
             >>> adata.layers["counts"] = adata.X.copy()
             >>> ps = pt.tl.PseudobulkSpace()
-            >>> pdata = ps.compute(
-            ...     adata,
-            ...     target_col="Patient",
-            ...     groups_col="Cluster",
-            ...     layer_key="counts",
-            ...     mode="sum",
-            ...     min_cells=10,
-            ...     min_counts=1000,
-            ... )
+            >>> pdata = ps.compute(adata, target_col="Patient", groups_col="Cluster", layer_key="counts", mode="sum")
             >>> edgr = pt.tl.EdgeR(pdata, design="~Efficacy+Treatment")
             >>> res_df = edgr.compare_groups(pdata, column="Efficacy", baseline="SD", groups_to_compare=["PR", "PD"])
             >>> edgr.plot_multicomparison_fc(res_df)


### PR DESCRIPTION
## Summary
Two small docs-only changes tied together by issue #615:

1. **DE docstring examples**: refresh the `Examples` blocks in `pertpy/tools/_differential_gene_expression/_base.py` (5 occurrences across `EdgeR`/`PyDESeq2` plot and `compare_groups` docstrings) so they use the current `PseudobulkSpace.compute(...)` signature. The previous examples passed the long-removed `min_cells=10`/`min_counts=1000` kwargs, so anyone copy-pasting them hit `TypeError: compute() got an unexpected keyword argument 'min_cells'`. Reported by @mschilli87 in #615.
2. **Intersphinx**: add `decoupler` to `docs/conf.py`'s `intersphinx_mapping` so MyST cross-references like `{func}` ``~decoupler.op.collectri`` `` (introduced in the companion tutorials PR scverse/pertpy-tutorials#60) resolve to decoupler's docs.