### PR TITLE
ci: bump codecov-action to v6 and fail CI on upload error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,9 @@ jobs:
           uvx hatch run ${{ matrix.env.name }}:cov-report   # report visibly
           uvx hatch run ${{ matrix.env.name }}:coverage xml # create report for upload
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
+        with:
+          fail_ci_if_error: true
 
   check:
     name: Tests pass in all hatch environments


### PR DESCRIPTION
Two changes to every codecov upload step in this repo:

1. **codecov-action -> `@v6`.** Versions below 6.0.2 verify the codecov CLI binary against Codecov's old Keybase key, which they bricked after migrating accounts, so uploads now fail with `Could not verify signature`. `@v6` (= 6.0.2) ships the updated key.
2. **`fail_ci_if_error: true`.** Matches the `cookiecutter-scverse` template default so a broken upload fails CI loudly instead of passing silently.

Ref: https://github.com/codecov/codecov-action/issues/1956